### PR TITLE
Add page title to index.html

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,5 +1,6 @@
 ---
 layout: default
+title: Home
 ---
 
 <div class="jumbotron">


### PR DESCRIPTION
The default template uses two Jekyll variables to define the title: page title and site title. Without a page title in index.html, the final title looks stupid.
