### PR TITLE
Removing the navigation link to the bountysource.

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -21,7 +21,6 @@
       <div class="container">
         <nav class="site-nav">
           <ul>
-            <li><a href="https://www.bountysource.com/fundraisers/539-neovim-first-iteration">Bountysource fundraiser</a></li>
             <li><a href="https://github.com/neovim/neovim">GitHub project</a></li>
             <li><a href="https://groups.google.com/forum/#!forum/neovim">Google Group</a></li>
             <li><a href="http://twitter.com/Neovim">@Neovim on Twitter</a></li>


### PR DESCRIPTION
The bountysource fundraiser has ended, so I propose removing the link to keep the navigation clean and concise.
