### PR TITLE
Update donation FAQ to point to Bountysource

### DIFF
--- a/index.html
+++ b/index.html
@@ -89,8 +89,8 @@ title: Home
          <dt>Will Neovim improve upon the default configuration that was found in Vim?</dt>
          <dd>This is being <a href="https://github.com/neovim/neovim/issues/276">discussed</a> but the community seems to be in favor of it.</dd>
 
-         <dt>I missed the Bountysource Fundraiser, can I still donate to Neovim?</dt>
-         <dd>The Neovim community is working with Bountysource to see if we can create a long standing donation solution.</dd>
+         <dt>Can I donate to Neovim's development?</dt>
+         <dd>By using Bountysource, you can either place a bounty on an issue or donate to the entire team by going to <a href="https://www.bountysource.com/teams/neovim">Neovim's Bountysource Team</a> page.</dd>
        </dl>
     </div>
 


### PR DESCRIPTION
I'm not sure if we want to add a link back to the top or not.
