### PR TITLE
[RFC] Prepare doc_index.html, add canonical URLs.

### DIFF
--- a/_data/nav.yml
+++ b/_data/nav.yml
@@ -3,7 +3,7 @@
 - title: News
   url: /news/
 - title: Documentation
-  url: /documentation/
+  url: /doc/
 - title: Google Group
   url: https://groups.google.com/forum/#!forum/neovim
 - title: Twitter

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -10,6 +10,7 @@
     <link href="http://fonts.googleapis.com/css?family=Lato:400,700,900" rel="stylesheet">
     <link href="/css/normalize.css" rel="stylesheet">
     <link href="/css/main.css" rel="stylesheet">
+    <link rel="canonical" href="http://neovim.org{% if page.canonical_url %}{{ page.canonical_url }}{% else %}{{ page.url }}{% endif %}" />
     <!--[if lt IE 9]>
       <script src="https://oss.maxcdn.com/libs/html5shiv/3.7.0/html5shiv.js"></script>
       <script src="https://oss.maxcdn.com/libs/respond.js/1.4.2/respond.min.js"></script>
@@ -22,14 +23,14 @@
     {% include footer.html %}
 
     <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.11.0/jquery.min.js"></script>
-		<script>
-			(function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-			(i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-			m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-			})(window,document,'script','//www.google-analytics.com/analytics.js','ga');
+    <script>
+      (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+      (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+      m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+      })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
 
-			ga('create', 'UA-48317591-1', 'neovim.org');
-			ga('send', 'pageview');
-		</script>
+      ga('create', 'UA-48317591-1', 'neovim.org');
+      ga('send', 'pageview');
+    </script>
   </body>
 </html>

--- a/doc_index.html
+++ b/doc_index.html
@@ -1,6 +1,7 @@
 ---
 layout: default
 title: Documentation
+canonical_url: /doc/
 ---
 
 {% include nav.html active='Documentation' %}


### PR DESCRIPTION
Using a canonical URL will help if a search engine ever discovers /doc_index. It will also remove "duplicate content" between e.g. `/news` and `/news/index.html`. I used absolute paths, as [Google](https://support.google.com/webmasters/answer/139066?hl=en) recommends it. I don't think that the domain name will ever change, so I hardcoded this into the layout. Also fixed mixed tabs/spaces.

See also neovim/bot-ci#6.
