### PR TITLE
[RFC] Exclude Gemfile, CNAME in Jekyll config.

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -18,5 +18,8 @@ gems:
     - jekyll-mentions
 
 exclude:
-    - README.md
+    - CNAME
+    - Gemfile
+    - Gemfile.lock
     - LICENSE
+    - README.md


### PR DESCRIPTION
A very small change just so that the following won't work anymore: http://neovim.org/Gemfile
