### PR TITLE
add FAQ and quickref

### DIFF
--- a/doc_index.html
+++ b/doc_index.html
@@ -30,6 +30,16 @@ canonical_url: /doc/
         Neovim's manual is not yet available online. In the meantime, you can use the <a href="http://vimdoc.sourceforge.net/htmldoc/usr_toc.html">Vim documentation</a> instead. If you have installed Neovim, you can also execute the <code>:help</code> command to access the manual.
       </p>
 
+      <h3>Quick Reference</h3>
+
+      <p>
+        Neovim (and Vim) ships with a <a href="http://vimhelp.appspot.com/quickref.txt.html">quick reference guide</a>:
+
+        <code>:help quickref</code>
+      </p>
+
+      <h3><a href="http://vimhelp.appspot.com/vim_faq.txt.html">Vim FAQ</a></h3>
+
       <h2>Developers & Contributors</h2>
 
       <h3>Neovim Wiki</h3>


### PR DESCRIPTION
This is just a stub to get these links up. I bet 90% of vim users didn't know Vim has a built-in quickref.

Eventually we'll want to maintain a Neovim FAQ instead of linking the Vim FAQ because much of the Vim FAQ will not be relevant to Neovim. Probably we should maintain the Neovim FAQ on the Neovim wiki since it isn't part of the shipped documentation.
