### PR TITLE
[RFC] Rename build-reports to reports.

### DIFF
--- a/doc_index.html
+++ b/doc_index.html
@@ -54,7 +54,7 @@ canonical_url: /doc/
 
       <h3>Clang Report</h3>
       <p>
-      Clang's static analyzer is executed periodically on the Neovim codebase. A list of current issues is published in the <a href="/doc/build-reports/clang">static analysis report</a>.
+      Clang's static analyzer is executed periodically on the Neovim codebase. A list of current issues is published in the <a href="/doc/reports/clang">static analysis report</a>.
       </p>
 
       <h3>Coverity Report</h3>
@@ -64,7 +64,7 @@ canonical_url: /doc/
 
       <h3>Translation Report</h3>
       <p>
-        An overview of the current status of translations in Neovim is published on the <a href="/doc/build-reports/translations">translation report page</a>.
+        An overview of the current status of translations in Neovim is published on the <a href="/doc/reports/translations">translation report page</a>.
       </p>
 
     </div>


### PR DESCRIPTION
Merge after neovim/doc#1, but before neovim/bot-ci#13. Also included a link to the vim patch report, hope that's okay.
