### PR TITLE
Use HTTPS where possible

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -9,11 +9,7 @@ task :test do
       /^\/doc\/$/ => '/doc_index/',
     }, :href_ignore => [
       # Ignore doc directories created by bot-ci.
-      '/doc/dev',
-      '/doc/reports/clang',
-      '/doc/reports/translations',
-      '/doc/reports/vimpatch',
-      '/doc/user',
+      /^\/doc\/.*$/,
   ]).run
 end
 

--- a/_config.yml
+++ b/_config.yml
@@ -8,7 +8,7 @@ description: "vim out of the box"
 news:
     name: Neovim Newsletter
     authors: Neovim Community
-    url: https://neovim.org/news
+    url: /news
     feed: /news.xml
 
 url: "https://neovim.org"

--- a/_config.yml
+++ b/_config.yml
@@ -8,10 +8,10 @@ description: "vim out of the box"
 news:
     name: Neovim Newsletter
     authors: Neovim Community
-    url: http://neovim.org/news
+    url: https://neovim.org/news
     feed: /news.xml
 
-url: "http://neovim.org"
+url: "https://neovim.org"
 
 gems:
     - jekyll-redirect-from

--- a/_data/nav.yml
+++ b/_data/nav.yml
@@ -7,7 +7,7 @@
 - title: Google Group
   url: https://groups.google.com/forum/#!forum/neovim
 - title: Twitter
-  url: http://twitter.com/Neovim
+  url: https://twitter.com/Neovim
 - title: Bountysource
   url: https://www.bountysource.com/teams/neovim
 - title: Development

--- a/_includes/news_sidebar.html
+++ b/_includes/news_sidebar.html
@@ -10,7 +10,7 @@
 
       <p>
         If you'd prefer this newsletter going to your inbox, use a solution
-        similar to <a href="http://blogtrottr.com/">Blogtrottr</a> which takes
+        similar to <a href="https://blogtrottr.com/">Blogtrottr</a> which takes
         an RSS feed and sends it to your email.
       </p>
 

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -7,10 +7,10 @@
     <meta name="description" content="{{site.description}}">
     <meta name="author" content="">
     <title>{% if page.title %}{{ page.title }} - {% endif %}{{ site.title }}</title>
-    <link href="http://fonts.googleapis.com/css?family=Lato:400,700,900" rel="stylesheet">
-    <link href="//cdnjs.cloudflare.com/ajax/libs/normalize/3.0.0/normalize.min.css" rel="stylesheet">
+    <link href="https://fonts.googleapis.com/css?family=Lato:400,700,900" rel="stylesheet">
+    <link href="https://cdnjs.cloudflare.com/ajax/libs/normalize/3.0.0/normalize.min.css" rel="stylesheet">
     <link href="/css/main.css" rel="stylesheet">
-    <link rel="canonical" href="http://neovim.org{% if page.canonical_url %}{{ page.canonical_url }}{% else %}{{ page.url }}{% endif %}" />
+    <link rel="canonical" href="https://neovim.org{% if page.canonical_url %}{{ page.canonical_url }}{% else %}{{ page.url }}{% endif %}" />
     <!--[if lt IE 9]>
       <script src="https://oss.maxcdn.com/libs/html5shiv/3.7.0/html5shiv.js"></script>
       <script src="https://oss.maxcdn.com/libs/respond.js/1.4.2/respond.min.js"></script>

--- a/_posts/2014-02-22-Back-Neovim-Through-Bountysource.md
+++ b/_posts/2014-02-22-Back-Neovim-Through-Bountysource.md
@@ -4,7 +4,7 @@ title: Back Neovim Through Bountysource
 author: Josh Branchaud
 ---
 
-[Neovim](http://github.com/neovim/neovim) is a project that seeks
+[Neovim](https://github.com/neovim/neovim) is a project that seeks
 to aggressively refactor [vim](http://www.vim.org/) source code. The current
 vim code base is unwieldy and difficult to maintain despite a community of
 developers wanting to extend and improve it. This project is an effort to
@@ -16,5 +16,5 @@ about Neovim to make this happen. If you can support Neovim through any size
 of financial contribution, do so at
 [Neovim's Bountysource page](https://www.bountysource.com/fundraisers/539-neovim-first-iteration).
 Your coding contributions are also welcome, so feel free to head on over to
-the [Neovim](http://github.com/neovim/neovim) project to submit issues and
+the [Neovim](https://github.com/neovim/neovim) project to submit issues and
 pull requests.

--- a/_posts/2014-06-06-june-newsletter.md
+++ b/_posts/2014-06-06-june-newsletter.md
@@ -222,7 +222,7 @@ Until next time. `:wq`
 [bountysource]: https://www.bountysource.com/
 [backers]: https://github.com/neovim/neovim/blob/master/BACKERS.md
 [libuv]: https://github.com/joyent/libuv
-[style]: https://neovim.org/development-wiki/style-guide/style-guide.xml
+[style]: /development-wiki/style-guide/style-guide.xml
 [vim-import]: https://github.com/neovim/neovim/commit/72cf89bce8e4230dbc161dc5606f48ef9884ba70
 [crypto-discussion]: https://github.com/neovim/neovim/issues/694
 [crypto-removal]: https://github.com/neovim/neovim/pull/699
@@ -270,7 +270,7 @@ Until next time. `:wq`
 [redraw]: https://github.com/neovim/neovim/pull/781
 [mailing]: https://groups.google.com/forum/#!forum/neovim
 [first-release]: https://groups.google.com/d/msg/neovim/KDgatetthQw/8rn4rdm8z8wJ
-[neovim.org]: https://neovim.org/
+[neovim.org]: /
 [eval.c]: https://raw.githubusercontent.com/neovim/neovim/master/src/nvim/eval.c
 [coverity-neovim]: https://scan.coverity.com/projects/2227
 [coverity]: https://scan.coverity.com/

--- a/_posts/2014-06-06-june-newsletter.md
+++ b/_posts/2014-06-06-june-newsletter.md
@@ -222,7 +222,7 @@ Until next time. `:wq`
 [bountysource]: https://www.bountysource.com/
 [backers]: https://github.com/neovim/neovim/blob/master/BACKERS.md
 [libuv]: https://github.com/joyent/libuv
-[style]: http://neovim.org/development-wiki/style-guide/style-guide.xml
+[style]: https://neovim.org/development-wiki/style-guide/style-guide.xml
 [vim-import]: https://github.com/neovim/neovim/commit/72cf89bce8e4230dbc161dc5606f48ef9884ba70
 [crypto-discussion]: https://github.com/neovim/neovim/issues/694
 [crypto-removal]: https://github.com/neovim/neovim/pull/699
@@ -248,7 +248,7 @@ Until next time. `:wq`
 [pr656]: https://github.com/neovim/neovim/pull/656
 [feat_]: https://github.com/neovim/neovim/pull/500
 [streams]: https://github.com/neovim/neovim/pull/556
-[format-strings]: http://en.wikipedia.org/wiki/Printf_format_string
+[format-strings]: https://en.wikipedia.org/wiki/Printf_format_string
 [pr296]: https://github.com/neovim/neovim/pull/296
 [pr490]: https://github.com/neovim/neovim/issues/490
 [pr574]: https://github.com/neovim/neovim/issues/574
@@ -258,10 +258,10 @@ Until next time. `:wq`
 [1st-bounty]: https://www.bountysource.com/issues/1563162-include-the-vim-breakindent-patch
 [job-control]: https://github.com/neovim/neovim/pull/475
 [unit]: https://github.com/neovim/neovim/tree/master/test/unit
-[c99]: http://en.wikipedia.org/wiki/C99
+[c99]: https://en.wikipedia.org/wiki/C99
 [cmake]: http://www.cmake.org/
 [msgpack-api]: https://github.com/neovim/neovim/pull/509
-[stat]: http://en.wikipedia.org/wiki/Stat_(system_call)
+[stat]: https://en.wikipedia.org/wiki/Stat_(system_call)
 [fs.c]: https://github.com/neovim/neovim/blob/master/src/nvim/os/fs.c
 [pr619]: https://github.com/neovim/neovim/pull/619
 [plugin-arch]: https://github.com/neovim/neovim/wiki/Plugin-UI-architecture
@@ -270,10 +270,10 @@ Until next time. `:wq`
 [redraw]: https://github.com/neovim/neovim/pull/781
 [mailing]: https://groups.google.com/forum/#!forum/neovim
 [first-release]: https://groups.google.com/d/msg/neovim/KDgatetthQw/8rn4rdm8z8wJ
-[neovim.org]: http://neovim.org/
+[neovim.org]: https://neovim.org/
 [eval.c]: https://raw.githubusercontent.com/neovim/neovim/master/src/nvim/eval.c
 [coverity-neovim]: https://scan.coverity.com/projects/2227
-[coverity]: http://scan.coverity.com/
+[coverity]: https://scan.coverity.com/
 [travis]: https://travis-ci.org/neovim/neovim
 [travis-osx]: https://github.com/neovim/neovim/issues/766
 [int-guideline]: https://github.com/neovim/neovim/wiki/Integer-types-refactoring-guidelines

--- a/_posts/2014-07-04-july-newsletter.md
+++ b/_posts/2014-07-04-july-newsletter.md
@@ -181,7 +181,7 @@ first Friday of August.
 
 Until next time. `:wq`
 
-[docs-dev]: https://neovim.org/doc/dev
+[docs-dev]: /doc/dev
 [docs-doxygen]: https://github.com/neovim/neovim.github.io/issues/48
 [docs-quotes]: http://hitchhikers.wikia.com/wiki/Marvin#Quotes_by_Marvin
 [docs-user]: https://github.com/neovim/neovim.github.io/issues/55

--- a/_posts/2014-07-04-july-newsletter.md
+++ b/_posts/2014-07-04-july-newsletter.md
@@ -181,7 +181,7 @@ first Friday of August.
 
 Until next time. `:wq`
 
-[docs-dev]: http://neovim.org/doc/dev
+[docs-dev]: https://neovim.org/doc/dev
 [docs-doxygen]: https://github.com/neovim/neovim.github.io/issues/48
 [docs-quotes]: http://hitchhikers.wikia.com/wiki/Marvin#Quotes_by_Marvin
 [docs-user]: https://github.com/neovim/neovim.github.io/issues/55
@@ -196,7 +196,7 @@ Until next time. `:wq`
 [license-apache]: https://tldrlegal.com/license/apache-license-2.0-(apache-2.0)
 [license-cla-doc]: https://docs.google.com/forms/d/1u54bpbwzneDIRltFx1TGi2evKxY3w0cOV3vlpj8DPbg/viewform
 [license-cla-wiki]: https://github.com/neovim/neovim/wiki/CLA-confirmation-page
-[license-cla]: http://en.wikipedia.org/wiki/Contributor_License_Agreement
+[license-cla]: https://en.wikipedia.org/wiki/Contributor_License_Agreement
 [license-concern]: https://github.com/neovim/neovim/issues/878
 [license-update]: https://github.com/neovim/neovim/pull/883
 [license-vim]: http://vimdoc.sourceforge.net/htmldoc/uganda.html#license

--- a/_posts/2014-09-06-september-newsletter.md
+++ b/_posts/2014-09-06-september-newsletter.md
@@ -204,12 +204,12 @@ Until next time. `:wq`
 [info-wiki]: https://github.com/neovim/neovim/wiki
 [info-libuv]: https://github.com/joyent/libuv
 [issues-1000th]: https://github.com/neovim/neovim/pull/1000
-[docs-home]: https://neovim.org/doc/
+[docs-home]: /doc/
 [docs-help]: https://github.com/neovim/neovim/pull/985
 [pipes-pr]: https://github.com/neovim/neovim/pull/978
 [pipes-selecta]: https://github.com/garybernhardt/selecta
 [pipes-bug]: https://github.com/neovim/neovim/issues/1044
-[newsletters-june]: https://neovim.org/news/2014/june/
+[newsletters-june]: /news/2014/june/
 [windows-master]: https://github.com/neovim/neovim/issues/696
 [windows-mingw-issue]: https://github.com/neovim/neovim/pull/810
 [windows-msvc]: http://msdn.microsoft.com/en-us/vstudio/hh386302.aspx

--- a/_posts/2014-09-06-september-newsletter.md
+++ b/_posts/2014-09-06-september-newsletter.md
@@ -204,12 +204,12 @@ Until next time. `:wq`
 [info-wiki]: https://github.com/neovim/neovim/wiki
 [info-libuv]: https://github.com/joyent/libuv
 [issues-1000th]: https://github.com/neovim/neovim/pull/1000
-[docs-home]: http://neovim.org/doc/
+[docs-home]: https://neovim.org/doc/
 [docs-help]: https://github.com/neovim/neovim/pull/985
 [pipes-pr]: https://github.com/neovim/neovim/pull/978
 [pipes-selecta]: https://github.com/garybernhardt/selecta
 [pipes-bug]: https://github.com/neovim/neovim/issues/1044
-[newsletters-june]: http://neovim.org/news/2014/june/
+[newsletters-june]: https://neovim.org/news/2014/june/
 [windows-master]: https://github.com/neovim/neovim/issues/696
 [windows-mingw-issue]: https://github.com/neovim/neovim/pull/810
 [windows-msvc]: http://msdn.microsoft.com/en-us/vstudio/hh386302.aspx
@@ -230,9 +230,9 @@ Until next time. `:wq`
 [python-client]: https://github.com/neovim/python-client
 [python-refactor]: https://github.com/neovim/python-client/pull/17
 [profile-pr]: https://github.com/neovim/neovim/pull/839
-[removal-sgi]: http://en.wikipedia.org/wiki/SGI_IRIS
-[removal-beos]: http://en.wikipedia.org/wiki/BeOS
-[removal-ebcdic]: http://en.wikipedia.org/wiki/EBCDIC
+[removal-sgi]: https://en.wikipedia.org/wiki/SGI_IRIS
+[removal-beos]: https://en.wikipedia.org/wiki/BeOS
+[removal-ebcdic]: https://en.wikipedia.org/wiki/EBCDIC
 [removal-pr1]: https://github.com/neovim/neovim/pull/814
 [removal-pr2]: https://github.com/neovim/neovim/pull/1006
 [temp-windows]: https://github.com/neovim/neovim/issues/812

--- a/_posts/2014-11-07-november-newsletter.md
+++ b/_posts/2014-11-07-november-newsletter.md
@@ -246,7 +246,7 @@ Until next time. `:wq`
 [floobits-blog]: https://news.floobits.com/2014/11/04/neovim/
 [floobits-repo]: https://github.com/Floobits/floobits-neovim
 
-[vim-patch-report]: https://neovim.org/doc/reports/vimpatch/
+[vim-patch-report]: /doc/reports/vimpatch/
 
 [legacy-first]: https://github.com/neovim/neovim/pull/1318
 [legacy-second]: https://github.com/neovim/neovim/pull/1328
@@ -273,7 +273,7 @@ Until next time. `:wq`
 [iconv-pr]: https://github.com/neovim/neovim/pull/1370
 [iconv-site]: http://www.gnu.org/software/libiconv/
 
-[int-types-newsletter]: https://neovim.org/news/2014/june/
+[int-types-newsletter]: /news/2014/june/
 [int-types-pr]: https://github.com/neovim/neovim/pull/1340
 [int-types-part-1]: https://github.com/neovim/neovim/pull/656
 [int-types-part-2]: https://github.com/neovim/neovim/pull/757
@@ -294,8 +294,8 @@ Until next time. `:wq`
 [clang-4]: https://github.com/neovim/neovim/pull/1478
 
 [plugin-pr]: https://github.com/neovim/neovim/pull/1454
-[plugin-remote-doc]: https://neovim.org/doc/user/remote_plugin.html#remote-plugin
-[plugin-provider-doc]: https://neovim.org/doc/user/nvim_provider.html#nvim-provider
+[plugin-remote-doc]: /doc/user/remote_plugin.html#remote-plugin
+[plugin-provider-doc]: /doc/user/nvim_provider.html#nvim-provider
 [plugin-comment]: https://github.com/neovim/neovim/issues/1501#issuecomment-63765917
 [plugin-1]: https://github.com/neovim/neovim/issues/1415
 [plugin-2]: https://github.com/neovim/neovim/issues/1459

--- a/_posts/2014-11-07-november-newsletter.md
+++ b/_posts/2014-11-07-november-newsletter.md
@@ -238,15 +238,15 @@ Until next time. `:wq`
 [info-twitter]: https://twitter.com/Neovim
 [info-wiki]: https://github.com/neovim/neovim/wiki
 
-[unixstickers-site]: http://www.unixstickers.com/
-[unixstickers-nvim]: http://www.unixstickers.com/tag/neovim
+[unixstickers-site]: https://www.unixstickers.com/
+[unixstickers-nvim]: https://www.unixstickers.com/tag/neovim
 [unixstickers-iccf]: http://iccf-holland.org/
 
 [floobits-site]: https://floobits.com/
 [floobits-blog]: https://news.floobits.com/2014/11/04/neovim/
 [floobits-repo]: https://github.com/Floobits/floobits-neovim
 
-[vim-patch-report]: http://neovim.org/doc/reports/vimpatch/
+[vim-patch-report]: https://neovim.org/doc/reports/vimpatch/
 
 [legacy-first]: https://github.com/neovim/neovim/pull/1318
 [legacy-second]: https://github.com/neovim/neovim/pull/1328
@@ -273,7 +273,7 @@ Until next time. `:wq`
 [iconv-pr]: https://github.com/neovim/neovim/pull/1370
 [iconv-site]: http://www.gnu.org/software/libiconv/
 
-[int-types-newsletter]: http://neovim.org/news/2014/june/
+[int-types-newsletter]: https://neovim.org/news/2014/june/
 [int-types-pr]: https://github.com/neovim/neovim/pull/1340
 [int-types-part-1]: https://github.com/neovim/neovim/pull/656
 [int-types-part-2]: https://github.com/neovim/neovim/pull/757
@@ -294,13 +294,13 @@ Until next time. `:wq`
 [clang-4]: https://github.com/neovim/neovim/pull/1478
 
 [plugin-pr]: https://github.com/neovim/neovim/pull/1454
-[plugin-remote-doc]: http://neovim.org/doc/user/remote_plugin.html#remote-plugin
-[plugin-provider-doc]: http://neovim.org/doc/user/nvim_provider.html#nvim-provider
+[plugin-remote-doc]: https://neovim.org/doc/user/remote_plugin.html#remote-plugin
+[plugin-provider-doc]: https://neovim.org/doc/user/nvim_provider.html#nvim-provider
 [plugin-comment]: https://github.com/neovim/neovim/issues/1501#issuecomment-63765917
 [plugin-1]: https://github.com/neovim/neovim/issues/1415
 [plugin-2]: https://github.com/neovim/neovim/issues/1459
 
-[box]: http://en.wikipedia.org/wiki/Out_of_the_box_feature
+[box]: https://en.wikipedia.org/wiki/Out_of_the_box_feature
 
 [job-rstream]: https://github.com/neovim/neovim/blob/master/src/nvim/os/rstream.c
 [job-pr]: https://github.com/neovim/neovim/pull/1255

--- a/develop/style-guide.xml
+++ b/develop/style-guide.xml
@@ -28,10 +28,10 @@ redirect_from:
     <SUMMARY>
       <p>
         This style guide is licensed under the
-        <a href="http://creativecommons.org/licenses/by/3.0/">CC-By 3.0</a>
+        <a href="https://creativecommons.org/licenses/by/3.0/">CC-By 3.0</a>
         License.
         It was originally created by
-        <a href="http://google-styleguide.googlecode.com/svn/trunk/cppguide.xml">Google</a>
+        <a href="https://google-styleguide.googlecode.com/svn/trunk/cppguide.xml">Google</a>
         and has been modified to fit Neovim's needs.
       </p>
     </SUMMARY>
@@ -704,7 +704,7 @@ redirect_from:
     one may be you!
   </p>
   <p>
-    Neovim uses <a href="http://en.wikipedia.org/wiki/Doxygen">Doxygen</a>
+    Neovim uses <a href="https://en.wikipedia.org/wiki/Doxygen">Doxygen</a>
     comments.
   </p>
 

--- a/doc_index.html
+++ b/doc_index.html
@@ -27,11 +27,11 @@ canonical_url: /doc/
       <h3>User Manual</h3>
 
       <p>
-      If you have installed Neovim, execute the <code>:help</code> command to access its <a href="http://neovim.org/doc/user">user manual</a>. For an overview of features specific to Neovim, see the <a href="http://neovim.org/doc/user/nvim_intro.html">introduction to Nvim</a> (<code>:help nvim-intro</code>). This also contains instructions on how to enable support for <a href="http://neovim.org/doc/user/nvim_python.html">Python plugins</a> (<code>:help nvim-python</code>) such as YouCompleteMe.
+      If you have installed Neovim, execute the <code>:help</code> command to access its <a href="https://neovim.org/doc/user">user manual</a>. For an overview of features specific to Neovim, see the <a href="https://neovim.org/doc/user/nvim_intro.html">introduction to Nvim</a> (<code>:help nvim-intro</code>). This also contains instructions on how to enable support for <a href="https://neovim.org/doc/user/nvim_python.html">Python plugins</a> (<code>:help nvim-python</code>) such as YouCompleteMe.
       </p>
 
       <p>
-        Other helpful resources for both Neovim and Vim are the <a href="http://neovim.org/doc/user/quickref.html">quick reference guide</a> (<code>:help quickref</code>) and the <a href="http://vimhelp.appspot.com/vim_faq.txt.html">Vim FAQ</a>.
+        Other helpful resources for both Neovim and Vim are the <a href="https://neovim.org/doc/user/quickref.html">quick reference guide</a> (<code>:help quickref</code>) and the <a href="https://vimhelp.appspot.com/vim_faq.txt.html">Vim FAQ</a>.
       </p>
 
       <h2>Developers & Contributors</h2>

--- a/doc_index.html
+++ b/doc_index.html
@@ -27,11 +27,11 @@ canonical_url: /doc/
       <h3>User Manual</h3>
 
       <p>
-      If you have installed Neovim, execute the <code>:help</code> command to access its <a href="https://neovim.org/doc/user">user manual</a>. For an overview of features specific to Neovim, see the <a href="https://neovim.org/doc/user/nvim_intro.html">introduction to Nvim</a> (<code>:help nvim-intro</code>). This also contains instructions on how to enable support for <a href="https://neovim.org/doc/user/nvim_python.html">Python plugins</a> (<code>:help nvim-python</code>) such as YouCompleteMe.
+      If you have installed Neovim, execute the <code>:help</code> command to access its <a href="/doc/user">user manual</a>. For an overview of features specific to Neovim, see the <a href="/doc/user/nvim_intro.html">introduction to Nvim</a> (<code>:help nvim-intro</code>). This also contains instructions on how to enable support for <a href="/doc/user/nvim_python.html">Python plugins</a> (<code>:help nvim-python</code>) such as YouCompleteMe.
       </p>
 
       <p>
-        Other helpful resources for both Neovim and Vim are the <a href="https://neovim.org/doc/user/quickref.html">quick reference guide</a> (<code>:help quickref</code>) and the <a href="https://vimhelp.appspot.com/vim_faq.txt.html">Vim FAQ</a>.
+        Other helpful resources for both Neovim and Vim are the <a href="/doc/user/quickref.html">quick reference guide</a> (<code>:help quickref</code>) and the <a href="https://vimhelp.appspot.com/vim_faq.txt.html">Vim FAQ</a>.
       </p>
 
       <h2>Developers & Contributors</h2>

--- a/index.html
+++ b/index.html
@@ -38,13 +38,13 @@ redirect_from:
         <h3>Project sponsors</h3>
 
         <div class="first-level-sponsor">
-          <a href="http://digitalocean.com"><img src="images/sponsors/digital-ocean@2x.png" alt="Logo of Digital Ocean" width="311"></a>
+          <a href="https://www.digitalocean.com"><img src="images/sponsors/digital-ocean@2x.png" alt="Logo of Digital Ocean" width="311"></a>
         </div>
 
         <table class="second-level-sponsors">
           <tr>
             <td>
-              <a href="http://bountysource.com"><img src="images/sponsors/bountysource@2x.png" alt="Logo of Bountysource" width="144"></a>
+              <a href="https://www.bountysource.com"><img src="images/sponsors/bountysource@2x.png" alt="Logo of Bountysource" width="144"></a>
             </td>
             <td>
               <a href="http://superjer.com"><img src="images/sponsors/superjer@2x.png" alt="Logo of SuperJer" width="119"></a>
@@ -120,7 +120,7 @@ redirect_from:
 
       <p><a href="logos/neovim-logos.zip">Neovim-logos.zip</a> <span class="light">(1.1 MB)</span></p>
 
-      <p class="light small">The Neovim logo by <a href="http://twitter.com/jasonlong">Jason Long</a> is licensed under the <a href="http://creativecommons.org/licenses/by/3.0/">Creative Commons Attribution 3.0 Unported License</a>.</p>
+      <p class="light small">The Neovim logo by <a href="https://twitter.com/jasonlong">Jason Long</a> is licensed under the <a href="https://creativecommons.org/licenses/by/3.0/">Creative Commons Attribution 3.0 Unported License</a>.</p>
     </div>
   </div>
 </section>
@@ -133,8 +133,8 @@ redirect_from:
       <h3>Stickers</h3>
       <p>
         Show off your choice in text editor with a set of
-        <a href="http://www.unixstickers.com/tag/neovim">Neovim stickers</a>
-        created by <a href="http://www.unixstickers.com/">Unixstickers</a>.
+        <a href="https://www.unixstickers.com/tag/neovim">Neovim stickers</a>
+        created by <a href="https://www.unixstickers.com/">Unixstickers</a>.
       </p>
       <p>
         A portion of each purchase will go toward Bram Moolenaar's, the creator


### PR DESCRIPTION
> This also fixes mixed-content warnings on https://neovim.org/ and adds a “www.” prefix when targets redirect to it.