### PR TITLE
Fix broken link

### DIFF
--- a/doc_index.html
+++ b/doc_index.html
@@ -21,7 +21,7 @@ canonical_url: /doc/
       <h3>Installation Instructions</h3>
 
       <p>
-        Neovim is currently under development, and no releases have been published yet. To install a pre-alpha, experimental version of Neovim, please refer to the <a href="https://github.com/neovim/neovim/wiki/Installing">installation instructions in the Neovim Wiki</a>.
+        Neovim is currently under development, and no releases have been published yet. To install a pre-alpha, experimental version of Neovim, please refer to the <a href="https://github.com/neovim/neovim/wiki/Installing-Neovim">installation instructions in the Neovim Wiki</a>.
       </p>
 
       <h3>User Manual</h3>


### PR DESCRIPTION
I renamed `Installing` -> `Installing-Neovim` for consistency with `Building-Neovim`, but was informed by @fwalch that this website depends on the old name, so this fixes that.