### PR TITLE
Sponsor page cleanup

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta name="description" content="{{site.description}}">
-    <meta name="author" content="">
     <title>{% if page.title %}{{ page.title }} - {% endif %}{{ site.title }}</title>
     <link href="http://fonts.googleapis.com/css?family=Lato:400,700,900" rel="stylesheet">
     <link href="//cdnjs.cloudflare.com/ajax/libs/normalize/3.0.0/normalize.min.css" rel="stylesheet">

--- a/css/main.css
+++ b/css/main.css
@@ -301,7 +301,7 @@ pre {
   margin-top: 10px;
 }
 
-#original-sponsors {
+.original-sponsors {
   width: 400px;
 }
 

--- a/css/main.css
+++ b/css/main.css
@@ -357,13 +357,13 @@ pre {
   padding-bottom: 20px;
 }
 
-.sponsor-logo {
+.sponsors-table .sponsor-logo {
   text-align: right;
   padding-bottom: 20px;
 }
 
-.sponsor-name,
-.sponsor-amount {
+.sponsors-table .sponsor-name,
+.sponsors-table .sponsor-amount {
   padding-left: 12px;
 }
 
@@ -383,6 +383,11 @@ footer .container {
   font-size: 12px;
   color: #777;
 }
+
+footer .col-narrow {
+  text-align: right;
+}
+
 @media (min-width: 568px) {
   footer .container {
     font-size: 14px;

--- a/css/main.css
+++ b/css/main.css
@@ -305,16 +305,8 @@ pre {
   width: 400px;
 }
 
-.sponsors-table {
-  margin-top: 20px;
-}
-
 .sponsors-main h3 {
   color: #54a23d;
-}
-
-.sponsor-name, .sponsor-amount {
-  padding-left: 30px;
 }
 
 .first-level-sponsor {
@@ -343,6 +335,40 @@ pre {
   .second-level-sponsor img {
     width: auto;
   }
+}
+
+
+/*
+ * Sponsors table
+ *
+ */
+.sponsors-table {
+  width: 100%;
+  margin-top: 20px;
+  line-height: 1;
+}
+
+.sponsors-table td {
+  vertical-align: middle;
+}
+
+.sponsors-table h3 {
+  margin: 0;
+  padding-bottom: 20px;
+}
+
+.sponsor-logo {
+  text-align: right;
+  padding-bottom: 20px;
+}
+
+.sponsor-name,
+.sponsor-amount {
+  padding-left: 12px;
+}
+
+.sponsor-amount {
+  white-space: nowrap;
 }
 
 /*

--- a/css/main.css
+++ b/css/main.css
@@ -62,6 +62,16 @@ blockquote small:before {
   content: '\2014 \00A0'
 }
 
+pre {
+  overflow: auto;
+  padding: 0.8rem;
+  border-radius: 0.2rem;
+  border: solid 1px rgba(0, 0, 0, 0.1);
+  background-color: rgba(0, 0, 0, 0.05);
+  white-space: pre-wrap;
+  font-size: 0.9rem;
+}
+
 
 /*
  * Content container
@@ -286,7 +296,6 @@ blockquote small:before {
  * Callout-style box
  */
 .sponsors-main {
-  /* background-color: #f5f5f5; */
   padding: 5px 20px;
   border-radius: 4px;
   margin-top: 10px;
@@ -296,11 +305,7 @@ blockquote small:before {
   width: 400px;
 }
 
-#slug-instructions {
-  width: 450px;
-}
-
-#sponsors {
+.sponsors-table {
   margin-top: 20px;
 }
 

--- a/css/main.css
+++ b/css/main.css
@@ -353,18 +353,34 @@ pre {
 }
 
 .sponsors-table h3 {
+  display: inline;
   margin: 0;
   padding-bottom: 20px;
+  position: relative;
+  top: -0.8rem;
 }
 
 .sponsors-table .sponsor-logo {
   text-align: right;
+  padding-right: 12px;
   padding-bottom: 20px;
+  width: 128px;
 }
 
-.sponsors-table .sponsor-name,
 .sponsors-table .sponsor-amount {
   padding-left: 12px;
+}
+
+.sponsors-table .sponsor-name {
+  background-image: linear-gradient(90deg, #fbfbfb 25%, #fbfbfb 75%, #ddd 75%);
+  background-size: 6px 2px;
+  background-position: 0 40%;
+  background-repeat: repeat-x;
+}
+
+.sponsors-table .sponsor-name h3 {
+  background-color: #fbfbfb;
+  padding-right: 10px;
 }
 
 .sponsor-amount {

--- a/original-sponsors.html
+++ b/original-sponsors.html
@@ -5,29 +5,31 @@ title: Original sponsors
 
 {% include nav.html active='Sponsors' %}
 
-<div id="original-sponsors" class="col-narrow">
-  <div>
-    <h3>Project sponsors(for the first campaign)</h3>
+<div class="container">
+  <div class="original-sponsors col-narrow">
+    <div>
+      <h3>Project sponsors(for the first campaign)</h3>
 
-    <div class="first-level-sponsor">
-      <a href="http://digitalocean.com"><img src="{{ site.baseurl }}/images/sponsors/digital-ocean@2x.png" alt="Logo of Digital Ocean" width="311"></a>
+      <div class="first-level-sponsor">
+        <a href="http://digitalocean.com"><img src="{{ site.baseurl }}/images/sponsors/digital-ocean@2x.png" alt="Logo of Digital Ocean" width="311"></a>
+      </div>
+
+      <table class="second-level-sponsors">
+        <tr>
+          <td>
+            <a href="http://bountysource.com"><img src="{{ site.baseurl }}/images/sponsors/bountysource@2x.png" alt="Logo of Bountysource" width="144"></a>
+          </td>
+          <td>
+            <a href="http://superjer.com"><img src="{{ site.baseurl }}/images/sponsors/superjer@2x.png" alt="Logo of SuperJer" width="119"></a>
+          </td>
+        </tr>
+        <tr>
+          <td>
+            <a href="http://ryandurk.com"><img src="{{ site.baseurl }}/images/sponsors/ryan-durk@2x.png" alt="Logo of Ryan Durk" width="125"></a>
+          </td>
+          <td>&nbsp;</td>
+        </tr>
+      </table>
     </div>
-
-    <table class="second-level-sponsors">
-      <tr>
-        <td>
-          <a href="http://bountysource.com"><img src="{{ site.baseurl }}/images/sponsors/bountysource@2x.png" alt="Logo of Bountysource" width="144"></a>
-        </td>
-        <td>
-          <a href="http://superjer.com"><img src="{{ site.baseurl }}/images/sponsors/superjer@2x.png" alt="Logo of SuperJer" width="119"></a>
-        </td>
-      </tr>
-      <tr>
-        <td>
-          <a href="http://ryandurk.com"><img src="{{ site.baseurl }}/images/sponsors/ryan-durk@2x.png" alt="Logo of Ryan Durk" width="125"></a>
-        </td>
-        <td>&nbsp;</td>
-      </tr>
-    </table>
   </div>
 </div>

--- a/sponsors.html
+++ b/sponsors.html
@@ -9,45 +9,55 @@ title: Sponsors
 <div class="container">
   <div class="col-wide">
     <h2>Current sponsors</h2>
-    <table id="sponsors">
-    </table>
+    <table class="sponsors-table" id="sponsors"></table>
     <script>var sponsorsDivId = 'sponsors', sponsorsFront = false;</script>
   </div>
+
   <div class="col-narrow">
     <h2>FAQ</h2>
-    <ol>
-      <li>
-        <strong>What is this list?</strong>
+    <dl class="faqs">
+      <dt>What is this list?</dt>
+      <dd>
         <p>These are the companies or individuals contributing a monthly amount to
-        help sustain Neovim development. See the <a
-       href="https://salt.bountysource.com/teams/neovim">bountysource
-       campaign</a> for more details.</p>
-      </li>
-      <li>
-        <strong>I'm a sponsor contributing $5/month but my URL is not listed,
-          which is what I expected from the bountysource reward description.
-          What is happening?</strong>
+        help sustain Neovim development. See the
+        <a href="https://salt.bountysource.com/teams/neovim">bountysource
+        campaign</a> for more details.</p>
+      </dd>
+
+      <dt>
+        <p>I'm a sponsor contributing $5/month but my URL is not listed,
+        which is what I expected from the bountysource reward description.
+        What is happening?</p>
+      </dt>
+      <dd>
         <p>Bountysource does not yet provide a UI for sponsors to inform their
         URL. Most URLs displayed in the list were obtained using the github API
         and a heuristic to match the bountysource slug(a sort of sponsor
         identifier) with the github username, but this method was error prone
         and failed for many sponsors, including those that don't have a github
         account.</p>
+
         <p>If you are pledging $5/month or more and want to have your URL
-        listed, please send a PR to <a
-        href="https://github.com/neovim/neovim.github.io/pulls">
-      neovim.github.io</a> with a new entry for your bountysource slug in the <a
-        href="https://github.com/neovim/neovim.github.io/blob/master/js/sponsors-override.js">js/sponsors-override.js</a> file.
-      You can obtain your bountysource slug with the following command:
-      <pre id="slug-instructions">curl --header 'Accept: application/vnd.bountysource+json; version=2' 'https://api.bountysource.com/supporters?team_slug=neovim&amp;per_page=10000&amp;page=1' 2&gt; /dev/null | python -m json.tool | grep -C5 $NAME | grep slug</pre> where $NAME should be replaced by your bountysource display name(as shown in the sponsor list).
-        </p>
-      </li>
-      <li>
-        <strong>Where are the original sponsors that used to be shown in the front
-          page?</strong>
+        listed, please send a PR to
+        <a href="https://github.com/neovim/neovim.github.io/pulls">
+        neovim.github.io</a> with a new entry for your bountysource slug in the
+        <a href="https://github.com/neovim/neovim.github.io/blob/master/js/sponsors-override.js">
+        js/sponsors-override.js</a> file. You can obtain your bountysource slug with the
+        following command:</p>
+
+        <pre><code>curl --header 'Accept: application/vnd.bountysource+json; version=2' 'https://api.bountysource.com/supporters?team_slug=neovim&amp;per_page=10000&amp;page=1' 2&gt; /dev/null | python -m json.tool | grep -C5 $NAME | grep slug</code></pre>
+
+        <p>where $NAME should be replaced by your bountysource display name(as shown in the sponsor list).</p>
+      </dd>
+
+      <dt>
+        Where are the original sponsors that used to be shown in the front page?
+      </dt>
+
+      <dd>
         <p>To fulfill the $250/month rewards for the new campaign, they were
-        moved to a separate <a href="{{ site.baseurl }}/original-sponsors">page</a>.</p>
-      </li>
-    </ol>
+          moved to a separate <a href="{{ site.baseurl }}/original-sponsors">page</a>.</p>
+      </dd>
+    </dl>
   </div>
 </div>


### PR DESCRIPTION
@tarruda I took a pass at some cleanup on the sponsors page.

I removed the hard coded width on the `pre` tag and let the text wrap there since it's so easy to miss 90% of the command. I also tweaked the styling on the sponsor list a bit.

Current (note the dollar sign / amount breaks at narrower widths):

![image](https://cloud.githubusercontent.com/assets/6104/7837741/e91d64e4-0456-11e5-9a46-63207a8c2c5d.png)

Updated:

![image](https://cloud.githubusercontent.com/assets/6104/7837762/06019346-0457-11e5-9458-72fa4017b61a.png)

