### PR TITLE
Sponsor table tweaks

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -360,7 +360,7 @@ pre {
   top: -0.8rem;
 }
 
-.sponsors-table .sponsor-logo {
+.sponsors-table .sponsor-image {
   text-align: right;
   padding-right: 12px;
   padding-bottom: 20px;


### PR DESCRIPTION
Just a small tweak to fix some formatting lost in the merge conflicts of #101. Everything was fixed by using `.sponsor-image` instead of `.sponsor-logo` as introduced in #100.

Current:

![screen shot 2015-05-28 at 7 33 41 am](https://cloud.githubusercontent.com/assets/6104/7859151/40f26a56-050c-11e5-89b0-18df3f69e6cf.png)

Updated:

![screen shot 2015-05-28 at 7 34 12 am](https://cloud.githubusercontent.com/assets/6104/7859156/49aad0fc-050c-11e5-9faa-0fe84b4c5e57.png)
