### PR TITLE
Make “Integration with declarations generator” section look better

### DIFF
--- a/develop/style-guide.xml
+++ b/develop/style-guide.xml
@@ -386,24 +386,29 @@ redirect_from:
       </CODE_SNIPPET>
     </BODY>
   </STYLEPOINT>
-  
+
   <STYLEPOINT title="Integration with declarations generator">
     <SUMMARY>
-      Every C file must contain #include of the generated header file,
-      guarded by #ifdef INCLUDE_GENERATED_DECLARATIONS.
+      <p>
+        Every C file must contain #include of the generated header file,
+        guarded by #ifdef INCLUDE_GENERATED_DECLARATIONS.
+      </p>
     </SUMMARY>
     <BODY>
-      Include must go after other #includes and typedefs in .c files and
-      after everything else in header files. It is allowed to omit
-      #include in a .c file if .c file does not contain any static
-      functions.
-      
-      Included file name consists of the .c file name without extension,
-      preceded by the directory name relative to src/nvim. Name of the
-      file containing static functions declarations ends with
-      <code>.c.generated.h</code>, <code>*.h.generated.h</code> files contain
-      only non-static function declarations.
-      <CODE_SNIPPET>
+      <p>
+        Include must go after other #includes and typedefs in .c files and
+        after everything else in header files. It is allowed to omit
+        #include in a .c file if .c file does not contain any static
+        functions.
+      </p>
+
+      <p>
+        Included file name consists of the .c file name without extension,
+        preceded by the directory name relative to src/nvim. Name of the
+        file containing static functions declarations ends with
+        <code>.c.generated.h</code>, <code>*.h.generated.h</code> files contain
+        only non-static function declarations.
+        <CODE_SNIPPET>
         // src/nvim/foo.c file
         #include &lt;stddef.h&gt;
 
@@ -414,19 +419,20 @@ redirect_from:
         #endif
 
         …
-      </CODE_SNIPPET>
-      <CODE_SNIPPET>
+        </CODE_SNIPPET>
+        <CODE_SNIPPET>
         // src/nvim/foo.h file
         #ifndef NVIM_FOO_H
         #define NVIM_FOO_H
-  
+
         …
-  
+
         #ifdef INCLUDE_GENERATED_DECLARATIONS
-        # include "foo.c.generated.h"
+        # include "foo.h.generated.h"
         #endif
-        #endif
-      </CODE_SNIPPET>
+        #endif  // NVIM_FOO_H
+        </CODE_SNIPPET>
+      </p>
     </BODY>
   </STYLEPOINT>
 


### PR DESCRIPTION
Also fixes two style errors inside:

1. `.c.generated.h` in header file (should be `.h.generated.h`).
2. Missing `// NVIM_FOO_H`.