### PR TITLE
Add pygeek website to sponsor override

### DIFF
--- a/js/sponsors-override.js
+++ b/js/sponsors-override.js
@@ -9,6 +9,9 @@ var sponsorOverride = {
     url: 'http://www.namely.com/',
     frontImageUrl: '{{ site.baseurl }}/images/sponsors/Namely_logo.jpg',
   },
+  '34279-pygeek': {
+    url: 'http://pygeek.com',
+  },
   '347-stefanpenner': {
     url: 'http://iamstef.net/',
   },


### PR DESCRIPTION
I'd also like to include this image as my avatar on the sponsors page (https://pbs.twimg.com/profile_images/378800000436837670/4933f9be3fd1c43573c70808a5833278.png).