### PR TITLE
Use HTTPS links.

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -14,6 +14,7 @@ task :test do
       '/doc/reports/translations',
       '/doc/reports/vimpatch',
       '/doc/user',
+      '#',
   ]).run
 end
 

--- a/_config.yml
+++ b/_config.yml
@@ -8,10 +8,10 @@ description: "vim out of the box"
 news:
     name: Neovim Newsletter
     authors: Neovim Community
-    url: http://neovim.io/news
+    url: /news
     feed: /news.xml
 
-url: "http://neovim.io"
+url: "https://neovim.io"
 
 gems:
     - jekyll-redirect-from

--- a/_includes/nav.html
+++ b/_includes/nav.html
@@ -5,10 +5,10 @@
 	    <div class="navbar-header">
 		<button type="button" class="navbar-toggle collapsed" data-toggle="collapse" data-target="#menu" aria-expanded="false">
 		    <span class="sr-only">Toggle navigation</span>
-		    <img src="{{ site.baseurl }}/images/icons/icon-menu.svg" alt="Toggle navigation" class="navbar-top-align">
+		    <img src="/images/icons/icon-menu.svg" alt="Toggle navigation" class="navbar-top-align">
 		</button>
-		<a href="{{ site.baseurl }}/" class="navbar-brand">
-		    <img src="{{ site.baseurl }}/images/logo@2x.png" id="navbar-logo" alt="Neovim">
+		<a href="/" class="navbar-brand">
+		    <img src="/images/logo@2x.png" id="navbar-logo" alt="Neovim">
 		</a>
 	    </div>
 	    <div class="collapse navbar-collapse navbar-top-align" id="menu">
@@ -19,20 +19,12 @@
 		    {% else %}
 		    <li>
 		    {% endif %}
-		    {% if nav.url contains 'http://' or nav.url contains 'https://' %}
 		    <a {% if nav.sections != null %}href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false"{% else %}href="{{ nav.url }}"{% endif %}>{{ nav.title }}</a>
-		    {% else %}
-		    <a {% if nav.sections != null %}href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false"{% else %}href="{{ site.baseurl }}{{ nav.url }}"{% endif %}>{{ nav.title }}</a>
-		    {% endif %}
 		    {% if nav.sections != null %}
 			<ul class="dropdown-menu">
 			{% for section in nav.sections %}
 			    <li>
-			    {% if section.url contains 'http://' or section.url contains 'https://' %}
 				<a href="{{ section.url }}">{{ section.title }}</a>
-			    {% else %}
-				<a href="{{ site.baseurl }}{{ section.url }}">{{ section.title }}</a>
-			    {% endif %}
 			    </li>
 			{% endfor %}
 			</ul>

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -6,11 +6,11 @@
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta name="description" content="{{site.description}}">
     <title>{% if page.title %}{{ page.title }} - {% endif %}{{ site.title }}</title>
-    <link href="http://fonts.googleapis.com/css?family=Lato:400,700,900" rel="stylesheet">
-    <link href="//cdnjs.cloudflare.com/ajax/libs/normalize/3.0.0/normalize.min.css" rel="stylesheet">
+    <link href="https://fonts.googleapis.com/css?family=Lato:400,700,900" rel="stylesheet">
+    <link href="https://cdnjs.cloudflare.com/ajax/libs/normalize/3.0.0/normalize.min.css" rel="stylesheet">
     <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.5/css/bootstrap.min.css">
-    <link href="{{ site.baseurl }}/css/main.css" rel="stylesheet">
-    <link rel="canonical" href="http://neovim.io{% if page.canonical_url %}{{ page.canonical_url }}{% else %}{{ page.url }}{% endif %}" />
+    <link href="/css/main.css" rel="stylesheet">
+    <link rel="canonical" href="{{ site.url }}{% if page.canonical_url %}{{ page.canonical_url }}{% else %}{{ page.url }}{% endif %}" />
     <!--[if lt IE 9]>
       <script src="https://oss.maxcdn.com/libs/html5shiv/3.7.0/html5shiv.js"></script>
       <script src="https://oss.maxcdn.com/libs/respond.js/1.4.2/respond.min.js"></script>
@@ -32,8 +32,8 @@
       ga('create', 'UA-48317591-1', 'auto');
       ga('send', 'pageview');
     </script>
-    <script src="{{ site.baseurl }}/js/sponsors-override.js"></script>
-    <script src="{{ site.baseurl }}/js/sponsors.js"></script>
+    <script src="/js/sponsors-override.js"></script>
+    <script src="/js/sponsors.js"></script>
     <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.5/js/bootstrap.min.js"></script>
   </body>
 </html>

--- a/_posts/2014-11-07-november-newsletter.md
+++ b/_posts/2014-11-07-november-newsletter.md
@@ -140,7 +140,7 @@ msgpack-rpc; the same mechanism that UI's will be using when communicating.
 #### Job Activity Bug Fix
 
 @splinterofchaos happened to [come across a bug][job-bug] in which a job
-activity's output may become corrupted. The [rstream][job-rstream] structure
+activity's output may become corrupted. The rstream structure
 could contain incomplete lines if the buffer fills up before reaching a `'\n'`
 character.
 
@@ -302,7 +302,6 @@ Until next time. `:wq`
 
 [box]: http://en.wikipedia.org/wiki/Out_of_the_box_feature
 
-[job-rstream]: https://github.com/neovim/neovim/blob/master/src/nvim/os/rstream.c
 [job-pr]: https://github.com/neovim/neovim/pull/1255
 [job-bug]: https://github.com/neovim/neovim/issues/1243
 

--- a/about.html
+++ b/about.html
@@ -10,8 +10,8 @@ title: About
 <h1>About</h1>
 
 <ul>
-    <li><a href="charter/">Charter</a></li>
-    <li><a href="roadmap/">Roadmap</a></li>
+    <li><a href="/charter/">Charter</a></li>
+    <li><a href="/roadmap/">Roadmap</a></li>
 </ul>
 
 </div>

--- a/develop/guide.xsl
+++ b/develop/guide.xsl
@@ -164,7 +164,7 @@ xmlns:fn="http://www.w3.org/2005/xpath-functions">
                     <LI><A href="/">Neovim Home</A></LI>
                   </UL>
                 </DIV>
-                <A href="/"><IMG class="logo" alt="Neovim logo" src="{{ site.baseurl }}/images/logo@2x.png" /></A>
+                <A href="/"><IMG class="logo" alt="Neovim logo" src="/images/logo@2x.png" /></A>
               </DIV>
             </HEADER>
             <DIV class="container">

--- a/index.html
+++ b/index.html
@@ -96,7 +96,7 @@ redirect_from:
     <div class="col-narrow">
       <h2>Stay informed</h2>
 
-      <p>Subscribe to the <a href="{{ site.baseurl }}/news">quasi-monthly newsletter</a> or follow us
+      <p>Subscribe to the <a href="/news">quasi-monthly newsletter</a> or follow us
       on Twitter to stay up-to-date on the latest project news.</p>
 
       <a href="https://twitter.com/Neovim" class="twitter-follow-button" data-show-count="false" data-size="large">Follow &#64;Neovim</a>
@@ -106,7 +106,7 @@ redirect_from:
 
       <p>SVG and PNG versions of the Neovim logo are available in the following zip file.</p>
 
-      <p><a href="{{ site.baseurl }}/logos/neovim-logos.zip">Neovim-logos.zip</a> <span class="light">(1.1 MB)</span></p>
+      <p><a href="/logos/neovim-logos.zip">Neovim-logos.zip</a> <span class="light">(1.1 MB)</span></p>
 
       <p class="light small">The Neovim logo by <a href="http://twitter.com/jasonlong">Jason Long</a> is licensed under the <a href="http://creativecommons.org/licenses/by/3.0/">Creative Commons Attribution 3.0 Unported License</a>.</p>
     </div>
@@ -140,7 +140,7 @@ redirect_from:
       <h3>Bitcoin</h3>
       <div class="donate">
         <div class="icon">
-          <img src="{{ site.baseurl }}/images/icons/bitcoin.png" alt="Bitcoin logo"/>
+          <img src="/images/icons/bitcoin.png" alt="Bitcoin logo"/>
         </div>
         <input class="donate" type="text" value="1Evu6wPrzjsjrNPdCYbHy3HT6ry2EzXFyQ" readonly="readonly">
       </div>

--- a/js/sponsors-override.js
+++ b/js/sponsors-override.js
@@ -3,11 +3,11 @@
 var sponsorOverride = {
   '32537-hautelook': {
     url: 'http://hautelook.github.io/',
-    frontImageUrl: '{{ site.baseurl }}/images/sponsors/hautelook-logo.png',
+    frontImageUrl: '/images/sponsors/hautelook-logo.png',
   },
   '32681-namely-labs-namelyhr-namely-com': {
     url: 'http://www.namely.com/',
-    frontImageUrl: '{{ site.baseurl }}/images/sponsors/Namely_logo.jpg',
+    frontImageUrl: '/images/sponsors/Namely_logo.jpg',
   },
   '34279-pygeek': {
     url: 'http://pygeek.com',

--- a/news.xml
+++ b/news.xml
@@ -5,8 +5,8 @@
 <feed xmlns="http://www.w3.org/2005/Atom">
 
     <title type="text" xml:lang="en">{{ site.news.name }}</title>
-    <link type="application/atom+xml" href="{{ site.baseurl }}{{ site.news.feed }}" rel="self"/>
-    <link type="text" href="{{ site.news.url }}" rel="alternate"/>
+    <link type="application/atom+xml" href="{{ site.url }}{{ site.news.feed }}" rel="self"/>
+    <link type="text" href="{{ site.url }}{{ site.news.url }}" rel="alternate"/>
     <updated>{{ site.time | date_to_xmlschema }}</updated>
     <id>{{ site.news.url }}</id>
     <author>
@@ -16,7 +16,7 @@
     {% for post in site.categories.newsletter %}
     <entry>
         <title>{{ post.title | xml_escape }}</title>
-        <link href="{{ site.baseurl }}{{ post.url }}"/>
+        <link href="{{ site.url }}{{ post.url }}"/>
         <updated>{{ post.date | date_to_xmlschema }}</updated>
         <id>{{ site.news.url }}{{ post.id }}</id>
         <content type="html">{{ post.content | xml_escape }}</content>

--- a/sponsors.html
+++ b/sponsors.html
@@ -60,21 +60,21 @@ title: Sponsors
       <dd>
         <p>
           <div class="first-level-sponsor">
-            <a href="http://digitalocean.com"><img src="{{ site.baseurl }}/images/sponsors/digital-ocean@2x.png" alt="Logo of Digital Ocean" width="311"></a>
+            <a href="http://digitalocean.com"><img src="/images/sponsors/digital-ocean@2x.png" alt="Logo of Digital Ocean" width="311"></a>
           </div>
 
           <table class="second-level-sponsors">
             <tr>
               <td>
-                <a href="http://bountysource.com"><img src="{{ site.baseurl }}/images/sponsors/bountysource@2x.png" alt="Logo of Bountysource" width="144"></a>
+                <a href="http://bountysource.com"><img src="/images/sponsors/bountysource@2x.png" alt="Logo of Bountysource" width="144"></a>
               </td>
               <td>
-                <a href="http://superjer.com"><img src="{{ site.baseurl }}/images/sponsors/superjer@2x.png" alt="Logo of SuperJer" width="119"></a>
+                <a href="http://superjer.com"><img src="/images/sponsors/superjer@2x.png" alt="Logo of SuperJer" width="119"></a>
               </td>
             </tr>
             <tr>
               <td>
-                <a href="http://ryandurk.com"><img src="{{ site.baseurl }}/images/sponsors/ryan-durk@2x.png" alt="Logo of Ryan Durk" width="125"></a>
+                <a href="http://ryandurk.com"><img src="/images/sponsors/ryan-durk@2x.png" alt="Logo of Ryan Durk" width="125"></a>
               </td>
               <td>&nbsp;</td>
             </tr>


### PR DESCRIPTION
Use HTTPS links to avoid "some unencrypted elements on this website"
warning when accessing https://neovim.io.

Also remove usages of "site.baseurl", which doesn't exist (i.e. is an
empty string), and fix warnings in HTML-Proofer.