### PR TITLE
Improve wording on home page.

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -9,11 +9,7 @@ task :test do
       /^\/doc\/$/ => '/doc_index/',
     }, :href_ignore => [
       # Ignore doc directories created by bot-ci.
-      '/doc/dev',
-      '/doc/reports/clang',
-      '/doc/reports/translations',
-      '/doc/reports/vimpatch',
-      '/doc/user',
+      /^\/doc\/.*$/,
       '#',
   ]).run
 end

--- a/index.html
+++ b/index.html
@@ -37,8 +37,9 @@ redirect_from:
 
       <h3>Drop-in replacement for Vim</h3>
       <p>Neovim is an <em>extension</em> of Vim: feature-parity and backwards
-      compatibility are high priorities. See <code>:help nvim-from-vim</code>
-      if you already use Vim.</p>
+      compatibility are high priorities. If you are already familiar with Vim,
+      see <a href="/doc/user/nvim_from_vim.html"><code>:help nvim-from-vim</code></a>
+      to learn about the differences.</p>
 
     </div>
     <div class="col-narrow">


### PR DESCRIPTION
User "sehnsucht" mentioned on IRC that the existing wording about `nvim_from_vim` might a bit ambiguous.
This is my take on it; suggestions welcome!