### PR TITLE
Specify pre font size for faq sidebar only

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -69,7 +69,6 @@ pre {
   border: solid 1px rgba(0, 0, 0, 0.1);
   background-color: rgba(0, 0, 0, 0.05);
   white-space: pre-wrap;
-  font-size: 0.9rem;
 }
 
 
@@ -231,6 +230,10 @@ pre {
   font-size: 15px;
   margin-left: 0;
   margin-bottom: 20px;
+}
+
+.faqs dd pre {
+  font-size: 0.9rem;
 }
 
 /*


### PR DESCRIPTION
My take on https://github.com/neovim/neovim.github.io/issues/122

* Remove global 'pre' font sizing to improve readability of the generated vim help documents.
* Add small sizing for `.faq dd pre` as it is primarily used for a copy-paste snippet for which readability is secondary.