### PR TITLE
Index Typo - Sticker/Charity Donation 

### DIFF
--- a/index.html
+++ b/index.html
@@ -129,7 +129,7 @@ redirect_from:
         created by <a href="http://www.unixstickers.com/">Unixstickers</a>.
       </p>
       <p>
-        A portion of each purchase will go toward the charity <a href="http://iccf-holland.org/">ICCF Holland</a>, which was created by the author of Vim Bram Moolenaar.
+        A portion of each purchase will go toward the charity <a href="http://iccf-holland.org/">ICCF Holland</a>, which was created by the author of Vim, Bram Moolenaar.
       </p>
       <h3 id="donate">Donate</h3>
       <p>

--- a/index.html
+++ b/index.html
@@ -129,9 +129,7 @@ redirect_from:
         created by <a href="http://www.unixstickers.com/">Unixstickers</a>.
       </p>
       <p>
-        A portion of each purchase will go toward Bram Moolenaar's, the creator
-        of Vim's, charity called <a href="http://iccf-holland.org/">ICCF
-        Holland</a>.
+        A portion of each purchase will go toward the charity <a href="http://iccf-holland.org/">ICCF Holland</a>, which was created by the author of Vim Bram Moolenaar.
       </p>
       <h3 id="donate">Donate</h3>
       <p>


### PR DESCRIPTION
**Singular minor typo change.**

"A portion of each purchase will go toward Bram Moolenaar's, the
creator of Vim's, charity called ICCF Holland."  includes a typo or
two.

Changed so that it now reads:
"A portion of each purchase will go toward the charity ICCF Holland,
which was created by the author of Vim, Bram Moolenaar."