### PR TITLE
Fix madis-nomme entry in sponsors list

### DIFF
--- a/js/sponsors-override.js
+++ b/js/sponsors-override.js
@@ -23,7 +23,7 @@ var sponsorOverride = {
   '34279-pygeek': {
     url: 'http://pygeek.com',
   },
-  '34942-madis': {
+  '34942-madis-nomme': {
     url: 'https://mad.is',
     name: 'Madis Nõmme'
   },


### PR DESCRIPTION
My entry didn't have the link again. This should fix it. Neovim is awesome.

<img width="626" alt="screen shot 2017-01-03 at 12 29 47" src="https://cloud.githubusercontent.com/assets/674621/21605228/6247510e-d1b0-11e6-811c-79d389bee83c.png">
