### PR TITLE
CI: update travis env

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,6 @@
+dist: bionic
 language: ruby
-sudo: false
 cache: bundler
-rvm:
-  - 2.2
 env:
   global:
     - NOKOGIRI_USE_SYSTEM_LIBRARIES=true


### PR DESCRIPTION
fix CI failure:

    $ bundle install --jobs=3 --retry=3 --deployment --path=${BUNDLE_PATH:-vendor/bundle}
    You must use Bundler 2 or greater with this lockfile.