### PR TITLE
Point to the tree-sitter tracking issue instead of a pull request

### DIFF
--- a/roadmap.html
+++ b/roadmap.html
@@ -31,7 +31,7 @@ title: Roadmap
 <ul>
   <li>Lua <em>remote plugin</em> host</li>
   <li>Lua user-config: <code>init.lua</code></li>
-  <li>Treesitter syntax engine <a href="https://github.com/neovim/neovim/pull/11113">#11113</a></li>
+  <li>Treesitter syntax engine <a href="https://github.com/neovim/neovim/issues/11724">#11724</a></li>
   <li><a href="https://github.com/Microsoft/language-server-protocol">LSP</a> client for code navigation, refactoring</li>
   <li>Extended marks (text properties, decorations, virtual text)</li>
 </ul>


### PR DESCRIPTION
This commit makes the link in the road map point to the tracking issue on github rather than an already merged pull request. This allows for easier monitoring of the current status of tree-sitter integration.