### PR TITLE
Fix word breaking on vim_diff

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -87,6 +87,7 @@ pre {
   border: solid 1px var(--border-color);
   background-color: var(--accent-bg-color);
   white-space: pre-wrap;
+  word-break: normal;
 }
 
 code {


### PR DESCRIPTION
I opened the [vim diff page](https://neovim.io/doc/user/vim_diff.html#nvim-features) on half of my laptop screen and saw the words breaking in the middle.
I fixed it and now the words won't break awkwardly in the middle when the screen is narrow.

Before:
![Screenshot_2020-09-04 Nvim documentation vim_diff](https://user-images.githubusercontent.com/26710540/92273915-f2228180-eef4-11ea-998b-1b0f984d5cba.png)

After:
![Screenshot_2020-09-04 Nvim documentation vim_diff(1)](https://user-images.githubusercontent.com/26710540/92273942-fbabe980-eef4-11ea-9737-8cedd34b1f8e.png)
