### PR TITLE
Fix sponsors layout to use golden grid

### DIFF
--- a/sponsors.html
+++ b/sponsors.html
@@ -5,14 +5,14 @@ title: Sponsors
 
 {% include nav.html active='Sponsors' %}
 
-<div class="container">
-  <div class="col-wide">
+<div class="container golden-grid">
+  <div>
     <h2>Sponsors</h2>
     <table class="sponsors-table" id="sponsors"></table>
     <script>var sponsorsDivId = 'sponsors', sponsorsFront = false;</script>
   </div>
 
-  <div class="col-narrow">
+  <div>
     <h2>FAQ</h2>
     <dl class="faqs">
       <dt>How can I sponsor Neovim?</dt>


### PR DESCRIPTION
Fix sponsors layout so it uses the new golden grid layout.

![](https://i.imgur.com/gy9Ncq9.png)