### PR TITLE
Update Sponsors info on Home Page

### DIFF
--- a/index.html
+++ b/index.html
@@ -169,8 +169,8 @@ redirect_from:
       <h3>Sponsor</h3>
 			<ul>
 				<li><a href="https://github.com/sponsors/neovim">Github Sponsors (100% to developers)</a></li>
-				<li><a href="https://salt.bountysource.com/teams/neovim">Bountysource</a></li>
 				<li><a href="https://opencollective.com/neovim">Open Collective</a></li>
+				<li><a href="https://salt.bountysource.com/teams/neovim">Bountysource</a></li>
 			</ul>
     </div>
 

--- a/index.html
+++ b/index.html
@@ -160,16 +160,17 @@ redirect_from:
 
 <section class="front-section">
 	<div class="container">
-		<h2 id="sponsor">Support the project</h2>
+		<h2 id="sponsor">Support Neovim</h2>
+
+			<p>Support the team making Neovim possible!</p>
 	</div>
 	<div class="container col3">
     <div>
-      <h3>Bountysource</h3>
-      <p>
-      You can donate to the
-      <a href="https://salt.bountysource.com/teams/neovim">Neovim project</a>
-      on Bountysource.
-      </p>
+      <h3>Sponsor</h3>
+			<ul>
+				<li><a href="https://github.com/sponsors/neovim">Github Sponsors (100% to developers)</a></li>
+				<li><a href="https://salt.bountysource.com/teams/neovim">Bountysource</a></li>
+			</ul>
     </div>
 
     <div>
@@ -188,9 +189,11 @@ redirect_from:
     </div>
 
     <div>
-      <h3>Logo</h3>
+      <h3>Tell Others</h3>
       <p><a href="/logos/neovim-logos.zip">Neovim-logos.zip</a> <span class="light">(1.1 MB)</span></p>
-      <p class="light small">The Neovim logo by <a href="http://twitter.com/jasonlong">Jason Long</a> is licensed under the <a href="http://creativecommons.org/licenses/by/3.0/">Creative Commons Attribution 3.0 Unported License</a>.</p>
+      <p class="light small">
+				The Neovim logo by <a href="http://twitter.com/jasonlong">Jason Long</a> is licensed under the <a href="http://creativecommons.org/licenses/by/3.0/">Creative Commons Attribution 3.0 Unported License</a>.
+			</p>
     </div>
 
   </div>

--- a/index.html
+++ b/index.html
@@ -162,7 +162,7 @@ redirect_from:
 	<div class="container">
 		<h2 id="sponsor">Support Neovim</h2>
 
-			<p>Support the team making Neovim possible!</p>
+		<p>Support the team making Neovim possible!</p>
 	</div>
 	<div class="container col3">
     <div>
@@ -170,6 +170,7 @@ redirect_from:
 			<ul>
 				<li><a href="https://github.com/sponsors/neovim">Github Sponsors (100% to developers)</a></li>
 				<li><a href="https://salt.bountysource.com/teams/neovim">Bountysource</a></li>
+				<li><a href="https://opencollective.com/neovim">Open Collective</a></li>
 			</ul>
     </div>
 


### PR DESCRIPTION
Update sponsors section on homepage to include (and prioritize github sponsors). 

![Screenshot_2020-12-08 Home - Neovim(7)](https://user-images.githubusercontent.com/15027/101547008-9ba36400-3977-11eb-82e8-1a0e3720ca04.png)
