### PR TITLE
deps: add webrick

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,3 +2,5 @@ source 'https://rubygems.org'
 
 # https://github.com/github/pages-gem
 gem 'github-pages', group: :jekyll_plugins
+
+gem "webrick"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -22,15 +22,19 @@ GEM
     em-websocket (0.5.2)
       eventmachine (>= 0.12.9)
       http_parser.rb (~> 0.6.0)
-    ethon (0.12.0)
-      ffi (>= 1.3.0)
+    ethon (0.13.0)
+      ffi (>= 1.15.0)
     eventmachine (1.2.7)
     execjs (2.7.0)
-    faraday (1.3.0)
+    faraday (1.4.1)
+      faraday-excon (~> 1.1)
       faraday-net_http (~> 1.0)
+      faraday-net_http_persistent (~> 1.1)
       multipart-post (>= 1.2, < 3)
-      ruby2_keywords
+      ruby2_keywords (>= 0.0.4)
+    faraday-excon (1.1.0)
     faraday-net_http (1.0.1)
+    faraday-net_http_persistent (1.1.0)
     ffi (1.15.0)
     forwardable-extended (2.6.0)
     gemoji (3.0.1)
@@ -253,6 +257,7 @@ GEM
       unf_ext
     unf_ext (0.0.7.7)
     unicode-display_width (1.7.0)
+    webrick (1.7.0)
     zeitwerk (2.4.2)
 
 PLATFORMS
@@ -260,6 +265,7 @@ PLATFORMS
 
 DEPENDENCIES
   github-pages
+  webrick
 
 BUNDLED WITH
-   2.2.15
+   2.2.16


### PR DESCRIPTION
Ruby 2 shipped webrick by default, but Ruby 3 does not. Installing it for Ruby 2
as well poses no harm.