### PR TITLE
fix: permalink changes the output folder

### DIFF
--- a/doc2/README.md
+++ b/doc2/README.md
@@ -1,2 +1,3 @@
 This folder is destined to be crawled by https://github.com/neovim/doc/ and not
 served directly.
+You must set the `canonical_url: doc/XXXX` to the front matter.

--- a/doc2/general.html
+++ b/doc2/general.html
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: Documentation
-permalink: /doc/general/
+canonical_url: /doc/general/
 ---
 
 {% include nav.html active='Documentation' %}

--- a/doc2/lsp.html
+++ b/doc2/lsp.html
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: LSP documentation
-permalink: /doc/lsp
+canonical_url: /doc/lsp
 ---
 
 {% include nav.html active='Documentation' %}

--- a/doc2/lua-resources.html
+++ b/doc2/lua-resources.html
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: Lua resources
-permalink: /doc/lua-resources/
+canonical_url: /doc/lua-resources/
 ---
 
 {% include nav.html active='Documentation' %}

--- a/doc2/treesitter.html
+++ b/doc2/treesitter.html
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: Tree-sitter documentation
-permalink: /doc/treesitter/
+canonical_url: /doc/treesitter/
 ---
 
 {% include nav.html active='Documentation' %}


### PR DESCRIPTION
thus nullifying my intention of putting the files in a different directory so that neovim/doc can crawl that directory: I 've tested locally and canonical_url seems like what I wanted in the first place