### PR TITLE
Fix target for Documentation link

### DIFF
--- a/_data/nav.yml
+++ b/_data/nav.yml
@@ -12,7 +12,7 @@
 - title: Development
   url: https://github.com/neovim/neovim
 - title: Documentation
-  url: /doc/
+  url: /doc/user/index.html
   sections:
     - title: General
       url: /doc/general/


### PR DESCRIPTION
The target /doc/ is a 404.  Instead, point to the top of the `user` section.