### PR TITLE
Resolve BTC link redirection

### DIFF
--- a/index.html
+++ b/index.html
@@ -156,7 +156,7 @@ redirect_from:
       <div>
         <div>Sponsor</div>
         <ul>
-          <li><a href="https://github.com/sponsors/neovim">Github Sponsors (100% to developers)</a></li>
+          <li><a href="https://github.com/sponsors/neovim">GitHub Sponsors (100% to developers)</a></li>
           <li><a href="https://opencollective.com/neovim">Open Collective</a></li>
         </ul>
       </div>
@@ -172,7 +172,7 @@ redirect_from:
 
         <p class="light small">
         View at
-        <a href="https://blockchain.info/address/1Evu6wPrzjsjrNPdCYbHy3HT6ry2EzXFyQ">Blockchain.info</a>.
+        <a href="https://www.blockchain.com/btc/address/1Evu6wPrzjsjrNPdCYbHy3HT6ry2EzXFyQ">Blockchain.com</a>.
         </p>
       </div>
 


### PR DESCRIPTION
It seems Blockchain.info are now Blockchain.com.

Also corrected an inconsistent case of "GitHub".