### PR TITLE
Fix the 404 in the footer docs ref

### DIFF
--- a/_data/nav.yml
+++ b/_data/nav.yml
@@ -12,7 +12,7 @@
 - title: Development
   url: https://github.com/neovim/neovim
 - title: Documentation
-  url: /doc/
+  url: /doc/general/
   sections:
     - title: General
       url: /doc/general/


### PR DESCRIPTION
The footer `Documentation` links redirects to `/docs` which is not a valid URL,
redirect the `Documentation` link in footer to `/docs/general` instead.

I'm getting a `404` status code when I click on "Documentation" in the footer.

<img width="1175" alt="Screen Shot 2022-02-27 at 00 20 48" src="https://user-images.githubusercontent.com/17013303/155869347-cfba5f9f-5cc6-433f-a565-9dc67d63c2d4.png">
