### PR TITLE
Use minified bootstrap JS/CSS

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -8,7 +8,7 @@
     {% feed_meta %}
     <title>{% if page.title %}{{ page.title }} - {% endif %}{{ site.title }}</title>
     <link href="/css/normalize.min.css" rel="stylesheet">
-		<link href="/css/bootstrap.css" rel="stylesheet">
+		<link href="/css/bootstrap.min.css" rel="stylesheet">
     <link href="/css/main.css" rel="stylesheet">
     <link rel="canonical" href="{{ site.url }}{% if page.canonical_url %}{{ page.canonical_url }}{% else %}{{ page.url }}{% endif %}" />
   </head>
@@ -22,6 +22,6 @@
 		<script src="/js/jquery.js"></script>
     <script src="/js/sponsors-override.js"></script>
     <script src="/js/sponsors.js"></script>
-		<script src="/js/bootstrap.js"></script>
+		<script src="/js/bootstrap.min.js"></script>
   </body>
 </html>


### PR DESCRIPTION
The minified versions of the bootstrap JavaScript and CSS are included
in the repository, but not referenced. In addition to saving bandwidth,
this also fixes the two 404s caused by the un-minified files trying to
call non-existent `.map` files.