### PR TITLE
revert use of minified CSS

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -8,7 +8,7 @@
     {% feed_meta %}
     <title>{% if page.title %}{{ page.title }} - {% endif %}{{ site.title }}</title>
     <link href="/css/normalize.min.css" rel="stylesheet">
-		<link href="/css/bootstrap.min.css" rel="stylesheet">
+		<link href="/css/bootstrap.css" rel="stylesheet">
     <link href="/css/main.css" rel="stylesheet">
     <link rel="canonical" href="{{ site.url }}{% if page.canonical_url %}{{ page.canonical_url }}{% else %}{{ page.url }}{% endif %}" />
   </head>
@@ -22,6 +22,6 @@
 		<script src="/js/jquery.js"></script>
     <script src="/js/sponsors-override.js"></script>
     <script src="/js/sponsors.js"></script>
-		<script src="/js/bootstrap.min.js"></script>
+		<script src="/js/bootstrap.js"></script>
   </body>
 </html>

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -22,6 +22,6 @@
 		<script src="/js/jquery.js"></script>
     <script src="/js/sponsors-override.js"></script>
     <script src="/js/sponsors.js"></script>
-		<script src="/js/bootstrap.js"></script>
+		<script src="/js/bootstrap.min.js"></script>
   </body>
 </html>


### PR DESCRIPTION
Reverts neovim/neovim.github.io#267

Layout is messed up:

<img width="665" alt="image" src="https://user-images.githubusercontent.com/1359421/165200514-00cc0ebc-e965-4f9a-aeba-0596f141e901.png">
