### PR TITLE
Label Neovim logo for accessibility

### DIFF
--- a/_includes/logo.svg
+++ b/_includes/logo.svg
@@ -1,4 +1,5 @@
-<svg xmlns="http://www.w3.org/2000/svg" style="height: 2.5em" viewBox="0 0 742 214">
+<svg xmlns="http://www.w3.org/2000/svg" role="img" width="173" height="50" viewBox="0 0 742 214" aria-label="Neovim">
+  <title>Neovim</title>
   <defs>
     <linearGradient x1="50%" y1="0%" x2="50%" y2="100%" id="a">
       <stop stop-color="#16B0ED" stop-opacity=".8" offset="0%" />

--- a/_includes/nav.html
+++ b/_includes/nav.html
@@ -2,7 +2,7 @@
   <nav class="navbar navbar-expand-lg">
     <div class="container-fluid">
       <a href="/" class="navbar-brand" aria-label="logo">
-				{% include logo.svg %}
+        {% include logo.svg %}
       </a>
 
       <button


### PR DESCRIPTION
Add both `aria-label` property and the SVG `<title>` tag to mark up the
graphic for screen reader accessibility. Use both for the widest
support.

Add `role="img"` to the SVG, since SVGs do not have graphics semantics
by default, and the logo is used as a graphic (obviously), so marking it
as one gets us a lot of proper accessibility for free.

Add the exact width and height in dedicated properties instead of inline
`style`; the `width` and `height` properties are static, so the browser
can calculate the size of the image before layout rendering, increasing
performance.

Note that the Github preview looks as if the image has shrank, but that's
only because the Github SVG parser doesn't interpret `style` tags, and
wouldn't have the right value with the existing `em` sizing anyway.

Minify the SVG code to reduce code over the wire, and hence page speed.

Re-tab the navigation HTML file, bringing the logo call into the same
spaces-as-indentation style as the rest of the file.