### PR TITLE
Add aria label to hamburger menu

### DIFF
--- a/_includes/nav.html
+++ b/_includes/nav.html
@@ -11,6 +11,7 @@
         data-bs-target="#neovim-navbar"
         class="navbar-toggler"
         aria-expanded="false"
+        aria-label="Main menu"
       >
         <span class="navbar-toggler-icon">
           <svg


### PR DESCRIPTION
Add an aria label to the main hamburger menu button. Since this element
is an icon, and thus does not provide any inherent textual context,
screen readers have nothing other than "button" to read here.