### PR TITLE
Prevent flash of invisible text

### DIFF
--- a/css/lato.css
+++ b/css/lato.css
@@ -3,6 +3,7 @@
   font-family: 'Lato';
   font-style: normal;
   font-weight: 300;
+  font-display: swap;
   src: local(''),
        url('../fonts/lato-v17-latin-300.woff2') format('woff2'), /* Chrome 26+, Opera 23+, Firefox 39+ */
        url('../fonts/lato-v17-latin-300.woff') format('woff'); /* Chrome 6+, Firefox 3.6+, IE 9+, Safari 5.1+ */
@@ -13,6 +14,7 @@
   font-family: 'Lato';
   font-style: italic;
   font-weight: 300;
+  font-display: swap;
   src: local(''),
        url('../fonts/lato-v17-latin-300italicwoff2') format('woff2'), /* Chrome 26+, Opera 23+, Firefox 39+ */
        url('../fonts/lato-v17-latin-300italic.woff') format('woff'); /* Chrome 6+, Firefox 3.6+, IE 9+, Safari 5.1+ */
@@ -23,6 +25,7 @@
   font-family: 'Lato';
   font-style: normal;
   font-weight: 400;
+  font-display: swap;
   src: local(''),
        url('../fonts/lato-v17-latin-regular.woff2') format('woff2'), /* Chrome 26+, Opera 23+, Firefox 39+ */
        url('../fonts/lato-v17-latin-regular.woff') format('woff'); /* Chrome 6+, Firefox 3.6+, IE 9+, Safari 5.1+ */
@@ -33,6 +36,7 @@
   font-family: 'Lato';
   font-style: italic;
   font-weight: 400;
+  font-display: swap;
   src: local(''),
        url('../fonts/lato-v17-latin-italic.woff2') format('woff2'), /* Chrome 26+, Opera 23+, Firefox 39+ */
        url('../fonts/lato-v17-latin-italic.woff') format('woff'); /* Chrome 6+, Firefox 3.6+, IE 9+, Safari 5.1+ */
@@ -43,6 +47,7 @@
   font-family: 'Lato';
   font-style: normal;
   font-weight: 700;
+  font-display: swap;
   src: local(''),
        url('../fonts/lato-v17-latin-700.woff2') format('woff2'), /* Chrome 26+, Opera 23+, Firefox 39+ */
        url('../fonts/lato-v17-latin-700.woff') format('woff'); /* Chrome 6+, Firefox 3.6+, IE 9+, Safari 5.1+ */
@@ -53,6 +58,7 @@
   font-family: 'Lato';
   font-style: italic;
   font-weight: 700;
+  font-display: swap;
   src: local(''),
        url('../fonts/lato-v17-latin-700italic.woff2') format('woff2'), /* Chrome 26+, Opera 23+, Firefox 39+ */
        url('../fonts/lato-v17-latin-700italic.woff') format('woff'); /* Chrome 6+, Firefox 3.6+, IE 9+, Safari 5.1+ */
@@ -62,6 +68,7 @@
   font-family: 'Lato';
   font-style: normal;
   font-weight: 300;
+  font-display: swap;
   src: local(''),
        url('../fonts/lato-v17-latin-300.woff2') format('woff2'), /* Super Modern Browsers */
        url('../fonts/lato-v17-latin-300.woff') format('woff'), /* Modern Browsers */
@@ -73,6 +80,7 @@
   font-family: 'Lato';
   font-style: italic;
   font-weight: 300;
+  font-display: swap;
   src: local(''),
        url('../fonts/lato-v17-latin-300italic.woff2') format('woff2'), /* Supe Modern Browsers */
        url('../fonts/lato-v17-latin-300italic.woff') format('woff'), /* Modern Browsers */
@@ -84,6 +92,7 @@
   font-family: 'Lato';
   font-style: normal;
   font-weight: 400;
+  font-display: swap;
   src: local(''),
        url('../fonts/lato-v17-latin-regular.woff2') format('woff2'), /* Super Modern Browsers */
        url('../fonts/lato-v17-latin-regular.woff') format('woff'), /* Modern Browsers */
@@ -95,6 +104,7 @@
   font-family: 'Lato';
   font-style: italic;
   font-weight: 400;
+  font-display: swap;
   src: local(''),
        url('../fonts/lato-v17-latin-italic.woff2') format('woff2'), /* Super Modern Browsers */
        url('../fonts/lato-v17-latin-italic.woff') format('woff'), /* Modern Browsers */
@@ -106,6 +116,7 @@
   font-family: 'Lato';
   font-style: normal;
   font-weight: 700;
+  font-display: swap;
   src: local(''),
        url('../fonts/lato-v17-latin-700.woff2') format('woff2'), /* Super Modern Browsers */
        url('../fonts/lato-v17-latin-700.woff') format('woff'), /* Modern Browsers */
@@ -117,6 +128,7 @@
   font-family: 'Lato';
   font-style: italic;
   font-weight: 700;
+  font-display: swap;
   src: local(''),
        url('../fonts/lato-v17-latin-700italic.woff2') format('woff2'), /* Super Modern Browsers */
        url('../fonts/lato-v17-latin-700italic.woff') format('woff'), /* Modern Browsers */


### PR DESCRIPTION
There is a period during page load where the web font is not downloaded,
so text is invisible. If there is a network hiccup, this state could
be permanent for the session.

Modern browsers support `font-display`, which controls strategies for
how to handle this problem.

Use the `swap` property, which strikes a balance between preferring the
specified web font, but quickly falling back to a default if it does not
load in time, so text will always be visible.

Older browsers will ignore the property, maintaining the current
behavior.

See https://developer.mozilla.org/en-US/docs/Web/CSS/@font-face/font-display