### PR TITLE
Mention 0.8 as the latest version

### DIFF
--- a/index.html
+++ b/index.html
@@ -107,7 +107,7 @@ redirect_from:
         <dt>What is the project status?</dt>
         <dd>
           The current <a href="https://github.com/neovim/neovim/releases/latest">stable release</a>
-          version is <code>0.7</code> (<a href="https://github.com/neovim/neovim/tags.atom">RSS</a>).
+          version is <code>0.8</code> (<a href="https://github.com/neovim/neovim/tags.atom">RSS</a>).
           See the <a href="roadmap/">roadmap</a> for progress and plans.
         </dd>
 


### PR DESCRIPTION
Since 0.8.0 has been release, it should be advertised as the latest available version of Neovim.