### PR TITLE
Use matrix.to link

### DIFF
--- a/index.html
+++ b/index.html
@@ -151,7 +151,7 @@ redirect_from:
       <ul>
         <li><a href="https://twitter.com/Neovim" class="twitter-follow-button">Follow &#64;Neovim</a></li>
         <li>Discuss the project at
-          <a href="https://app.element.io/#/room/#neovim:matrix.org">#neovim:matrix.org</a>
+          <a href="https://matrix.to/#/#neovim:matrix.org">#neovim:matrix.org</a>
           or #neovim on <code>irc.libera.chat</code>.
         </li>
         <li>Contribute code, report bugs and request features at <a href="https://github.com/neovim/neovim">GitHub</a>.</li>


### PR DESCRIPTION
Linking directly into a matrix client app is discouraged. It is recommended to use [Matrix.to instead](https://matrix.to). [Matrix.to instead](https://matrix.to) provides a client agnostic way to link to a matrix room/space/event/etc, with support for a large number of clients.