### PR TITLE
fix: news section layout in mobile view

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -529,3 +529,11 @@ iframe.poll {
   width: 100%;
   overflow-y: hidden;
 }
+
+/*
+ * News section
+ */
+
+ .news-section table {
+    margin-top: 1rem;
+ }

--- a/index.html
+++ b/index.html
@@ -75,7 +75,7 @@ redirect_from:
       <div class="news-section">
         <h2 id="news">News</h2>
 
-        <a class="twitter-timeline" data-lang="en" data-width="400" data-height="300" href="https://twitter.com/Neovim?ref_src=twsrc%5Etfw">Tweets by Neovim</a>
+        <a class="twitter-timeline" data-lang="en" data-height="300" href="https://twitter.com/Neovim?ref_src=twsrc%5Etfw">Tweets by Neovim</a>
         <script async src="https://platform.twitter.com/widgets.js" charset="utf-8"></script>
 
         {% comment %} <dl class="nvim-posts"> {% endcomment %}


### PR DESCRIPTION
New section is broken in mobile view. The horizontal scrollbar show up. This PR is to let twitter timeline to decide width and add margin to table in news section.