### PR TITLE
fix(css): override default bootstrap style for DocSearch

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -566,5 +566,5 @@ iframe.poll {
  */
 
  .DocSearch mark {
-     padding: 0;
+   padding: 0;
  }

--- a/css/main.css
+++ b/css/main.css
@@ -560,3 +560,11 @@ iframe.poll {
  .news-section table {
     margin-top: 1rem;
  }
+
+/*
+ * DocSearch overrides
+ */
+
+ .DocSearch mark {
+     padding: 0;
+ }


### PR DESCRIPTION
Discussed in https://github.com/neovim/neovim.github.io/issues/310

It seems like the default bootstrap style adds a padding to the `mark` element, which makes the display of DocSearch results a bit weird (see `before`). This PR provides an override for the `mark` element, only if it's a child of the `DocSearch` class (see `after`).

| Before | After |
|--------|--------|
| <img width="1131" alt="Screenshot 2023-06-27 at 22 46 33" src="https://github.com/neovim/neovim.github.io/assets/20689156/df91d21a-f34e-412c-88b0-3e6382c7f988"> | <img width="1197" alt="Screenshot 2023-06-27 at 22 47 10" src="https://github.com/neovim/neovim.github.io/assets/20689156/eb54506b-4f90-4bbe-9046-98dab1e5e4cd"> | 

