### PR TITLE
feat(search): match DocSearch style with Neovim

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -7,16 +7,16 @@
     <meta name="description" content="{{site.description}}">
     {% feed_meta %}
     <title>{% if page.title %}{{ page.title }} - {% endif %}{{ site.title }}</title>
-    <link href="/css/normalize.min.css" rel="stylesheet">
-    <link href="/css/bootstrap.min.css" rel="stylesheet">
-    <link href="/css/main.css" rel="stylesheet">
-    <link href="/css/neovim-hi.css" rel="stylesheet">
-    <link rel="canonical" href="{{ site.url }}{% if page.canonical_url %}{{ page.canonical_url }}{% else %}{{ page.url }}{% endif %}" />
 
     <!-- algolia docsearch https://docsearch.algolia.com/docs/docsearch-v3/ -->
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@docsearch/css@3" />
     <link rel="preconnect" href="https://X185E15FPG-dsn.algolia.net" crossorigin />
 
+    <link href="/css/normalize.min.css" rel="stylesheet">
+    <link href="/css/bootstrap.min.css" rel="stylesheet">
+    <link href="/css/main.css" rel="stylesheet">
+    <link href="/css/neovim-hi.css" rel="stylesheet">
+    <link rel="canonical" href="{{ site.url }}{% if page.canonical_url %}{{ page.canonical_url }}{% else %}{{ page.url }}{% endif %}" />
   </head>
 
   <body>

--- a/css/main.css
+++ b/css/main.css
@@ -566,5 +566,5 @@ iframe.poll {
  */
 
  .DocSearch mark {
-     padding: 0;
+   padding: 0;
  }

--- a/css/main.css
+++ b/css/main.css
@@ -560,3 +560,11 @@ iframe.poll {
  .news-section table {
     margin-top: 1rem;
  }
+
+/*
+ * DocSearch overrides
+ */
+
+ .DocSearch mark {
+     padding: 0;
+ }

--- a/css/main.css
+++ b/css/main.css
@@ -565,6 +565,97 @@ iframe.poll {
  * DocSearch overrides
  */
 
- .DocSearch mark {
-   padding: 0;
- }
+:root {
+    --docsearch-primary-color: var(--accent-color);
+    --docsearch-text-color: var(--fg-color);
+    --docsearch-highlight-color: var(--link-color);
+    --docsearch-container-background: rgba(231, 238, 232, 0.2);
+
+    /* modal */
+    --docsearch-modal-background: var(--bg-color);
+    --docsearch-modal-shadow: none;
+
+    /* searchbox */
+    --docsearch-searchbox-background: var(--accent-bg-color);
+    --docsearch-searchbox-focus-background: var(--accent-bg-color);
+
+    /* hit */
+    --docsearch-hit-color: var(--docsearch-text-color);
+    --docsearch-hit-active-color: #fff;
+    --docsearch-hit-background: var(--accent-bg-color);
+    --docsearch-hit-shadow: none;
+
+    /* key */
+    --docsearch-key-gradient: transparent;
+    --docsearch-key-shadow: none;
+
+    /* footer */
+    --docsearch-footer-background: var(--bg-color);
+    --docsearch-footer-shadow: none;
+}
+
+@media (prefers-color-scheme: dark) {
+    :root {
+        --docsearch-primary-color: var(--accent-color);
+        --docsearch-text-color: var(--fg-color);
+        --docsearch-highlight-color: var(--link-color);
+        --docsearch-container-background: rgba(231, 238, 232, 0.2);
+
+        /* modal */
+        --docsearch-modal-background: var(--bg-color);
+        --docsearch-modal-shadow: none;
+
+        /* searchbox */
+        --docsearch-searchbox-background: var(--accent-bg-color);
+        --docsearch-searchbox-focus-background: var(--accent-bg-color);
+
+        /* hit */
+        --docsearch-hit-color: var(--docsearch-text-color);
+        --docsearch-hit-active-color: #fff;
+        --docsearch-hit-background: var(--accent-bg-color);
+        --docsearch-hit-shadow: none;
+
+        /* key */
+        --docsearch-key-gradient: transparent;
+        --docsearch-key-shadow: none;
+
+        /* footer */
+        --docsearch-footer-background: var(--bg-color);
+        --docsearch-footer-shadow: none;
+    }
+}
+
+.DocSearch mark {
+    padding: 0;
+}
+
+.DocSearch footer {
+    border-top: 1px solid var(--link-color)
+}
+
+.DocSearch-Button-Key {
+    top: 0;
+    padding: 0;
+    margin-right: 0;
+    width: auto;
+}
+
+.DocSearch-Button-Keys {
+    border-radius: 4px;
+    padding: 0 6px;
+    min-width: auto;
+    border: 1px solid var(--hi-b-black);
+}
+
+@media (prefers-color-scheme: dark) {
+    .DocSearch footer {
+        border-top: 1px solid var(--link-color)
+    }
+
+    .DocSearch-Button-Keys {
+        border-radius: 4px;
+        padding: 0 6px;
+        min-width: auto;
+        border: 1px solid var(--hi-b-black);
+    }
+}

--- a/css/main.css
+++ b/css/main.css
@@ -566,6 +566,36 @@ iframe.poll {
  */
 
 :root {
+  --docsearch-primary-color: var(--accent-color);
+  --docsearch-text-color: var(--fg-color);
+  --docsearch-highlight-color: var(--link-color);
+  --docsearch-container-background: rgba(231, 238, 232, 0.2);
+
+  /* modal */
+  --docsearch-modal-background: var(--bg-color);
+  --docsearch-modal-shadow: none;
+
+  /* searchbox */
+  --docsearch-searchbox-background: var(--accent-bg-color);
+  --docsearch-searchbox-focus-background: var(--accent-bg-color);
+
+  /* hit */
+  --docsearch-hit-color: var(--docsearch-text-color);
+  --docsearch-hit-active-color: #fff;
+  --docsearch-hit-background: var(--accent-bg-color);
+  --docsearch-hit-shadow: none;
+
+  /* key */
+  --docsearch-key-gradient: transparent;
+  --docsearch-key-shadow: none;
+
+  /* footer */
+  --docsearch-footer-background: var(--bg-color);
+  --docsearch-footer-shadow: none;
+}
+
+@media (prefers-color-scheme: dark) {
+  :root {
     --docsearch-primary-color: var(--accent-color);
     --docsearch-text-color: var(--fg-color);
     --docsearch-highlight-color: var(--link-color);
@@ -592,70 +622,48 @@ iframe.poll {
     /* footer */
     --docsearch-footer-background: var(--bg-color);
     --docsearch-footer-shadow: none;
-}
-
-@media (prefers-color-scheme: dark) {
-    :root {
-        --docsearch-primary-color: var(--accent-color);
-        --docsearch-text-color: var(--fg-color);
-        --docsearch-highlight-color: var(--link-color);
-        --docsearch-container-background: rgba(231, 238, 232, 0.2);
-
-        /* modal */
-        --docsearch-modal-background: var(--bg-color);
-        --docsearch-modal-shadow: none;
-
-        /* searchbox */
-        --docsearch-searchbox-background: var(--accent-bg-color);
-        --docsearch-searchbox-focus-background: var(--accent-bg-color);
-
-        /* hit */
-        --docsearch-hit-color: var(--docsearch-text-color);
-        --docsearch-hit-active-color: #fff;
-        --docsearch-hit-background: var(--accent-bg-color);
-        --docsearch-hit-shadow: none;
-
-        /* key */
-        --docsearch-key-gradient: transparent;
-        --docsearch-key-shadow: none;
-
-        /* footer */
-        --docsearch-footer-background: var(--bg-color);
-        --docsearch-footer-shadow: none;
-    }
+  }
 }
 
 .DocSearch mark {
-    padding: 0;
+  padding: 0;
 }
 
 .DocSearch footer {
-    border-top: 1px solid var(--link-color)
+  border-top: 1px solid var(--link-color)
 }
 
 .DocSearch-Button-Key {
-    top: 0;
-    padding: 0;
-    margin-right: 0;
-    width: auto;
+  top: 0;
+  padding: 0;
+  margin-right: 0;
+  width: auto;
 }
 
 .DocSearch-Button-Keys {
+  border-radius: 4px;
+  padding: 0 6px;
+  min-width: auto;
+  border: 1px solid var(--hi-b-black);
+}
+
+.DocSearch-Button {
+  border:  1px solid var(--docsearch-primary-color)
+}
+
+@media (prefers-color-scheme: dark) {
+  .DocSearch footer {
+      border-top: 1px solid var(--link-color)
+  }
+
+  .DocSearch-Button-Keys {
     border-radius: 4px;
     padding: 0 6px;
     min-width: auto;
     border: 1px solid var(--hi-b-black);
-}
+  }
 
-@media (prefers-color-scheme: dark) {
-    .DocSearch footer {
-        border-top: 1px solid var(--link-color)
-    }
-
-    .DocSearch-Button-Keys {
-        border-radius: 4px;
-        padding: 0 6px;
-        min-width: auto;
-        border: 1px solid var(--hi-b-black);
-    }
+  .DocSearch-Button {
+    border:  1px solid var(--docsearch-primary-color)
+  }
 }


### PR DESCRIPTION
> disclaimer: take a look at https://github.com/neovim/neovim.github.io/pull/328 first as this branch is stacked on it.

This PR aims at matching the DocSearch styles to the Neovim colors, see table for preview.

| Description | Before | After |
|:--------:|--------|--------|
| Update of the search button and keys | <img width="1280" alt="Screenshot 2023-06-28 at 00 11 16" src="https://github.com/neovim/neovim.github.io/assets/20689156/ad9207fc-ef02-4a58-8991-fe199e3e060b"> | <img width="1280" alt="Screenshot 2023-06-28 at 22 45 57" src="https://github.com/neovim/neovim.github.io/assets/20689156/dfab73ea-f282-42a5-9749-c8fae5d94459"> |
| Update of the modal and result highlights | <img width="1280" alt="Screenshot 2023-06-28 at 00 12 01" src="https://github.com/neovim/neovim.github.io/assets/20689156/bbfeb44e-9c3a-46b5-b920-ebe5c8c918bc"> | <img width="1280" alt="Screenshot 2023-06-28 at 00 12 21" src="https://github.com/neovim/neovim.github.io/assets/20689156/09fd1dbd-0290-4911-acc4-d6604b07f988"> | 

Feel free to suggest changes / color variations.