### PR TITLE
fix: remove broken twitter widget

### DIFF
--- a/index.html
+++ b/index.html
@@ -10,7 +10,11 @@ redirect_from:
 <section class="masthead">
   <h1 class="lead">hyperextensible Vim-based text editor</h1>
   <p>
-    <a href="https://github.com/neovim/neovim/wiki/Installing-Neovim" class="btn">Install Now</a>
+    <a
+      href="https://github.com/neovim/neovim/wiki/Installing-Neovim"
+      class="btn"
+      >Install Now</a
+    >
     <a href="https://neovimcraft.com/" class="btn">Get Plugins</a>
   </p>
 </section>
@@ -32,18 +36,18 @@ redirect_from:
           <a href="http://msgpack.org/">MessagePack</a> structured communication
           enables extensions in any language.
         </li>
+        <li>Remote plugins run as co-processes, safely and asynchronously.</li>
         <li>
-          Remote plugins run as co-processes, safely and asynchronously.
+          GUIs, IDEs, web browsers can <code>--embed</code> Neovim as an editor
+          or script host.
         </li>
         <li>
-          GUIs, IDEs, web browsers can <code>--embed</code> Neovim as an editor or script host.
+          <a href="/doc/user/lua.html">Lua plugins</a> are easy to create just
+          like Vimscript plugins. Your config can live in <code>init.lua</code>!
         </li>
         <li>
-          <a href="/doc/user/lua.html">Lua plugins</a> are easy to create just like Vimscript plugins.
-          Your config can live in <code>init.lua</code>!
-        </li>
-        <li>
-          AST-producing <a href="https://tree-sitter.github.io/">parsing engine</a>
+          AST-producing
+          <a href="https://tree-sitter.github.io/">parsing engine</a>
           enables faster, more accurate syntax highlighting, code navigation,
           refactoring, text objects, and motions.
         </li>
@@ -52,62 +56,86 @@ redirect_from:
       <h3>Usable</h3>
       <ul>
         <li>
-          Builtin <a href="/doc/user/lsp.html">LSP client</a> for
-          semantic code inspection and refactoring (go-to definition, "find references", format, …)
+          Builtin <a href="/doc/user/lsp.html">LSP client</a> for semantic code
+          inspection and refactoring (go-to definition, "find references",
+          format, …)
         </li>
-        <li>Strong <a href="/doc/user/vim_diff.html#nvim-defaults">defaults</a></li>
+        <li>
+          Strong <a href="/doc/user/vim_diff.html#nvim-defaults">defaults</a>
+        </li>
         <li>Works the same everywhere: one build-type, one command</li>
-        <li>Modern terminal features such as cursor styling, focus events, bracketed paste</li>
-        <li>Builtin <a href="https://www.youtube.com/watch?v=xZbMVj9XSUo">terminal emulator</a></li>
+        <li>
+          Modern terminal features such as cursor styling, focus events,
+          bracketed paste
+        </li>
+        <li>
+          Builtin
+          <a href="https://www.youtube.com/watch?v=xZbMVj9XSUo"
+            >terminal emulator</a
+          >
+        </li>
       </ul>
 
       <h3>Drop-in Vim</h3>
       <ul>
-        <li>
-          Fully compatible with Vim's editing model and Vimscript v1.
-        </li>
+        <li>Fully compatible with Vim's editing model and Vimscript v1.</li>
         <li>
           Start with
-          <a href="/doc/user/nvim.html#nvim-from-vim"><code>:help nvim-from-vim</code></a>
+          <a href="/doc/user/nvim.html#nvim-from-vim"
+            ><code>:help nvim-from-vim</code></a
+          >
           if you already use Vim.
         </li>
       </ul>
-
     </div>
     <div class="col-narrow">
       <div class="news-section">
         <h2 id="news">News</h2>
 
-        <a class="twitter-timeline" data-lang="en" data-height="300" href="https://twitter.com/Neovim?ref_src=twsrc%5Etfw">Tweets by Neovim</a>
-        <script async src="https://platform.twitter.com/widgets.js" charset="utf-8"></script>
-
-        {% comment %} <dl class="nvim-posts"> {% endcomment %}
-        <table>
-        {% assign posts_to_show = 2 %}
-        {% for post in site.posts limit:posts_to_show %}
-          <tr>
-            <td><a href="{{ post.url }}">{{ post.title }}</a>&nbsp;&nbsp; </td>
-            <td style="white-space: nowrap; text-align: right">{{ post.date | date:"%Y.%m" }}</td>
-          </tr>
-          {% comment %} <dd></dd> {% endcomment %}
-        {% endfor %}
-        </table>
-        {% comment %} </dl> {% endcomment %}
+        {% comment %}
+        <dl class="nvim-posts">
+          {% endcomment %}
+          <table>
+            {% assign posts_to_show = 2 %} {% for post in site.posts
+            limit:posts_to_show %}
+            <tr>
+              <td><a href="{{ post.url }}">{{ post.title }}</a>&nbsp;&nbsp;</td>
+              <td style="white-space: nowrap; text-align: right">
+                {{ post.date | date:"%Y.%m" }}
+              </td>
+            </tr>
+            {% comment %}
+            <dd></dd>
+            {% endcomment %} {% endfor %}
+          </table>
+          {% comment %}
+        </dl>
+        {% endcomment %}
 
         <p><a href="/news/archive">More…</a></p>
 
         <h2>Impressions</h2>
         <p>
-          "Neovim is exactly what it claims to be. It fixes every issue I have with Vim."
-          <a href="http://geoff.greer.fm/2015/01/15/why-neovim-is-better-than-vim/">—Geoff Greer</a>
+          "Neovim is exactly what it claims to be. It fixes every issue I have
+          with Vim."
+          <a
+            href="http://geoff.greer.fm/2015/01/15/why-neovim-is-better-than-vim/"
+            >—Geoff Greer</a
+          >
         </p>
         <p>
           "Lua for plugins and config is SO good. I love it."
-          <a href="https://www.reddit.com/r/neovim/comments/io2snh/neovim_lua_config_example/">—@Wolfy87</a>
+          <a
+            href="https://www.reddit.com/r/neovim/comments/io2snh/neovim_lua_config_example/"
+            >—@Wolfy87</a
+          >
         </p>
         <p>
           "A nice looking website, that’s one thing Neovim did right."
-          <a href="https://www.binpress.com/vim-creator-bram-moolenaar-interview/">—Bram Moolenaar</a>
+          <a
+            href="https://www.binpress.com/vim-creator-bram-moolenaar-interview/"
+            >—Bram Moolenaar</a
+          >
         </p>
       </div>
     </div>
@@ -119,8 +147,14 @@ redirect_from:
     <div>
       <h2>Intro</h2>
       <div class="intro-video-container">
-        <iframe class="intro-video" src="https://www.youtube-nocookie.com/embed/c4OyfL5o7DU" title="Neovim in 100 seconds" frameborder="0"
-          allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>
+        <iframe
+          class="intro-video"
+          src="https://www.youtube-nocookie.com/embed/c4OyfL5o7DU"
+          title="Neovim in 100 seconds"
+          frameborder="0"
+          allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
+          allowfullscreen
+        ></iframe>
       </div>
     </div>
 
@@ -134,16 +168,28 @@ redirect_from:
 
       <h2 id="chat">Chat</h2>
       <ul>
-        <li><a href="https://twitter.com/Neovim" class="twitter-follow-button">Follow &#64;Neovim</a></li>
-        <li>Discuss the project at
-          <a href="https://matrix.to/#/#neovim:matrix.org">#neovim:matrix.org</a>
+        <li>
+          <a href="https://twitter.com/Neovim" class="twitter-follow-button"
+            >Follow &#64;Neovim</a
+          >
+        </li>
+        <li>
+          Discuss the project at
+          <a href="https://matrix.to/#/#neovim:matrix.org"
+            >#neovim:matrix.org</a
+          >
           or #neovim on <code>irc.libera.chat</code>.
         </li>
-        <li>Contribute code, report bugs and request features at <a href="https://github.com/neovim/neovim">GitHub</a>.</li>
-        <li>Ask about usage and configuration at <a href="https://vi.stackexchange.com">vi.stackexchange.com</a>.</li>
+        <li>
+          Contribute code, report bugs and request features at
+          <a href="https://github.com/neovim/neovim">GitHub</a>.
+        </li>
+        <li>
+          Ask about usage and configuration at
+          <a href="https://vi.stackexchange.com">vi.stackexchange.com</a>.
+        </li>
       </ul>
     </div>
-
   </div>
 </section>
 
@@ -154,24 +200,38 @@ redirect_from:
       <dl class="faqs">
         <dt>What is the project status?</dt>
         <dd>
-          The current <a href="https://github.com/neovim/neovim/releases/latest">stable release</a>
-          version is <code>0.9</code> (<a href="https://github.com/neovim/neovim/tags.atom">RSS</a>).
-          See the <a href="roadmap/">roadmap</a> for progress and plans.
+          The current
+          <a href="https://github.com/neovim/neovim/releases/latest"
+            >stable release</a
+          >
+          version is <code>0.9</code> (<a
+            href="https://github.com/neovim/neovim/tags.atom"
+            >RSS</a
+          >). See the <a href="roadmap/">roadmap</a> for progress and plans.
         </dd>
 
         <dt>Is Neovim trying to turn Vim into an IDE?</dt>
-        <dd>With 30% less source-code than Vim, the <a href="charter/">vision</a>
-        of Neovim is to enable new applications without compromising Vim's
-        traditional roles. </dd>
+        <dd>
+          With 30% less source-code than Vim, the
+          <a href="charter/">vision</a> of Neovim is to enable new applications
+          without compromising Vim's traditional roles.
+        </dd>
 
         <dt>Will Neovim deprecate Vimscript?</dt>
         <dd>
           No. Lua is built-in, but Vimscript is supported with the
-          <a href="/doc/user/api.html#nvim_parse_expression()">world's most advanced Vimscript engine</a>.
+          <a href="/doc/user/api.html#nvim_parse_expression()"
+            >world's most advanced Vimscript engine</a
+          >.
         </dd>
 
         <dt>Which plugins does Neovim support?</dt>
-        <dd>Vim 8.x plugins and <a href="https://github.com/neovim/neovim/wiki/Related-projects">much more</a>.</dd>
+        <dd>
+          Vim 8.x plugins and
+          <a href="https://github.com/neovim/neovim/wiki/Related-projects"
+            >much more</a
+          >.
+        </dd>
       </dl>
     </div>
   </div>
@@ -184,8 +244,14 @@ redirect_from:
       <div>
         <div>Sponsor</div>
         <ul>
-          <li><a href="https://github.com/sponsors/neovim">GitHub Sponsors (100% to developers)</a></li>
-          <li><a href="https://opencollective.com/neovim">Open Collective</a></li>
+          <li>
+            <a href="https://github.com/sponsors/neovim"
+              >GitHub Sponsors (100% to developers)</a
+            >
+          </li>
+          <li>
+            <a href="https://opencollective.com/neovim">Open Collective</a>
+          </li>
         </ul>
       </div>
 
@@ -193,22 +259,38 @@ redirect_from:
         <label for="donate-input">Bitcoin</label>
         <div class="donate">
           <div class="icon">
-            <img src="/images/icons/bitcoin.png" alt="Bitcoin logo"/>
+            <img src="/images/icons/bitcoin.png" alt="Bitcoin logo" />
           </div>
-          <input id="donate-input" class="donate" type="text" value="1Evu6wPrzjsjrNPdCYbHy3HT6ry2EzXFyQ" readonly="readonly">
+          <input
+            id="donate-input"
+            class="donate"
+            type="text"
+            value="1Evu6wPrzjsjrNPdCYbHy3HT6ry2EzXFyQ"
+            readonly="readonly"
+          />
         </div>
 
         <p class="light small">
-        View at
-        <a href="https://www.blockchain.com/btc/address/1Evu6wPrzjsjrNPdCYbHy3HT6ry2EzXFyQ">Blockchain.com</a>.
+          View at
+          <a
+            href="https://www.blockchain.com/btc/address/1Evu6wPrzjsjrNPdCYbHy3HT6ry2EzXFyQ"
+            >Blockchain.com</a
+          >.
         </p>
       </div>
 
       <div>
         <div>Marketing</div>
         <ul>
-          <li><a href="/logos/neovim-logos.zip">Neovim-logos.zip</a> <span class="light">(1.1 MB)</span></li>
-          <li>Neovim logo by <a href="http://twitter.com/jasonlong">Jason Long</a>, <a href="http://creativecommons.org/licenses/by/3.0/">CC BY 3.0</a>.</li>
+          <li>
+            <a href="/logos/neovim-logos.zip">Neovim-logos.zip</a>
+            <span class="light">(1.1 MB)</span>
+          </li>
+          <li>
+            Neovim logo by
+            <a href="http://twitter.com/jasonlong">Jason Long</a>,
+            <a href="http://creativecommons.org/licenses/by/3.0/">CC BY 3.0</a>.
+          </li>
         </ul>
       </div>
     </div>


### PR DESCRIPTION
Remove the broken twitter widget from homepage news section.

<img width="977" alt="Screenshot 2023-07-08 at 23 28 49" src="https://github.com/neovim/neovim.github.io/assets/5558193/710568ff-eda5-41fb-a91a-d16858c5ff1f">
