### PR TITLE
doc: update links to content moved out of Neovim Wiki

### DIFF
--- a/doc2/index.html
+++ b/doc2/index.html
@@ -14,10 +14,10 @@ canonical_url: /doc/
     <div>
       <h2>User</h2>
 
-      <h3><a href="https://github.com/neovim/neovim/wiki/Installing-Neovim">Install</a></h3>
+      <h3><a href="https://github.com/neovim/neovim/blob/master/INSTALL.md">Install</a></h3>
       <p>
         <a href="https://github.com/neovim/neovim/releases">Download a binary</a>
-        or use a <a href="https://github.com/neovim/neovim/wiki/Installing-Neovim#install-from-package">package manager</a>.
+        or use a <a href="https://github.com/neovim/neovim/blob/master/INSTALL.md#install-from-package">package manager</a>.
       </p>
 
       <h3>
@@ -28,7 +28,7 @@ canonical_url: /doc/
           <li>Neovim features: <a href="/doc/user/vim_diff.html#nvim-features"><code>:help nvim-features</code></a></li>
           <li>Read <a href="/doc/user/nvim.html#nvim-from-vim"><code>:help nvim-from-vim</code></a> if you already use Vim.</li>
           <li>Read about <a href="/doc/user/lua.html">Lua in Nvim</a></li>
-          <li>Check the <a href="https://github.com/neovim/neovim/wiki/FAQ">FAQ</a>
+          <li>Check the <a href="https://neovim.io/doc/user/faq.html#faq">FAQ</a>
             and <a href="https://neovim.io/doc/user/news.html#news-breaking">breaking changes</a> for common issues.</li>
         </ul>
       </p>
@@ -39,9 +39,11 @@ canonical_url: /doc/
 
       <h3>Resources</h3>
       <ul>
+	<li><a href="https://github.com/neovim/neovim/blob/master/BUILD.md">Building Nvim from source</a></li>
+	<li><a href="https://github.com/neovim/neovim/blob/master/CONTRIBUTING.md">Contributing to Neovim</a></li>
         <li><a href="https://neovim.io/doc/user/develop.html#dev"><code>:help dev</code></a> guidelines and design constraints</li>
-        <li><a href="https://github.com/neovim/neovim/wiki#developers">Developer Wiki</a></li>
-        <li><a href="https://sourcegraph.com/github.com/neovim/neovim">Sourcegraph</a> explore Nvim's source code</li>
+	<li><a href="https://neovim.io/doc/user/dev_tools.html#dev-tools"><code>:help dev-tools</code></a> tools and techniques</li>
+        <li><a href="https://sourcegraph.com/github.com/neovim/neovim">Sourcegraph</a> for exploring Nvim's source code</li>
       </ul>
 
       <h3>API clients</h3>

--- a/index.html
+++ b/index.html
@@ -10,7 +10,7 @@ redirect_from:
 <section class="masthead">
   <h1 class="lead">hyperextensible Vim-based text editor</h1>
   <p>
-    <a href="https://github.com/neovim/neovim/wiki/Installing-Neovim" class="btn">Install Now</a>
+    <a href="https://github.com/neovim/neovim/blob/master/INSTALL.md" class="btn">Install Now</a>
     <a href="https://dotfyle.com/plugins" class="btn">Get Plugins</a>
   </p>
 </section>

--- a/roadmap.html
+++ b/roadmap.html
@@ -122,7 +122,7 @@ Concrete high-level feature areas and changes.
 <ul>
   <li>API: <a href="https://neovim.io/doc/user/api.html#api-buffer-updates">buffer update events</a></li>
   <li>Vimscript expression parser: <code>nvim_parse_expression()</code></li>
-  <li>Windows: <a href="https://github.com/neovim/neovim/wiki/Building-Neovim#windows--msvc">MSVC support</a></li>
+  <li>Windows: <a href="https://github.com/neovim/neovim/blob/master/BUILD.md#windows--msvc">MSVC support</a></li>
   <li><a href="https://github.com/neovim/neovim/milestone/15?closed=1">0.2.1</a> Built-in Lua:<code>vim.api</code>, <code>:lua</code>,
      <code>nvim_execute_lua()</code>, …</li>
   <li><a href="https://github.com/neovim/neovim/milestone/15?closed=1">0.2.1</a> Externalize UI components: cmdline, wildmenu</li>


### PR DESCRIPTION
Follow-up to the Wiki cleanup on neovim/neovim.

@dundargoc