### PR TITLE
roadmap: add bash to the list of new treesitter parsers

### DIFF
--- a/roadmap.html
+++ b/roadmap.html
@@ -51,7 +51,7 @@ Concrete high-level feature areas and changes.
 <h3><a href="https://github.com/neovim/neovim/milestone/36">0.10</a></h3>
 <ul>
   <li><a href="https://github.com/neovim/neovim/pull/26334">Default colorscheme</a></li>
-  <li>treesitter: builtin parsers for markdown, python</li>
+  <li>treesitter: builtin parsers for bash, markdown, python</li>
   <li><code>vim.iter<code></li>
 </ul>
 


### PR DESCRIPTION
neovim 0.10.0-dev builds include the following new parsers:
 * bash, markdown, python
 
Tree-sitter parsers in the 0.9 branch:
 * https://github.com/neovim/neovim/blob/release-0.9/cmake.deps/cmake/BuildTreesitterParsers.cmake#L37-L39

versus tree-sitter parsers in the 0.10-dev branch:
 * https://github.com/neovim/neovim/blob/master/cmake.deps/cmake/BuildTreesitterParsers.cmake#L37-L40

This can also be checked by downloading the binary linux tarballs and check the list of dynamic link libraries under the parser/ subdirectory. For example:


neovim 0.10.0-dev nightly:
```
$ curl -L https://github.com/neovim/neovim/releases/download/nightly/nvim-linux64.tar.gz
$ tar tf nvim-linux64.tar.gz  | grep parser | sort
nvim-linux64/lib/nvim/parser/
nvim-linux64/lib/nvim/parser/bash.so
nvim-linux64/lib/nvim/parser/c.so
nvim-linux64/lib/nvim/parser/lua.so
nvim-linux64/lib/nvim/parser/markdown_inline.so
nvim-linux64/lib/nvim/parser/markdown.so
nvim-linux64/lib/nvim/parser/python.so
nvim-linux64/lib/nvim/parser/query.so
nvim-linux64/lib/nvim/parser/vimdoc.so
nvim-linux64/lib/nvim/parser/vim.so
```

