### PR TITLE
Add link to Github discussions

### DIFF
--- a/index.html
+++ b/index.html
@@ -131,12 +131,12 @@ redirect_from:
       <h2 id="chat">Chat</h2>
       <ul>
         <li><a href="https://twitter.com/Neovim" class="twitter-follow-button">Follow &#64;Neovim</a></li>
-        <li>Discuss the project at
-          <a href="https://matrix.to/#/#neovim:matrix.org">#neovim:matrix.org</a>
+        <li>Discuss the project on <a href="https://github.com/neovim/neovim/discussions">Github</a>, or
+          join live discussions at <a href="https://matrix.to/#/#neovim:matrix.org">#neovim:matrix.org</a>
           or #neovim on <code>irc.libera.chat</code>.
         </li>
         <li>Contribute code, report bugs and request features at <a href="https://github.com/neovim/neovim">GitHub</a>.</li>
-        <li>Ask about usage and configuration at <a href="https://vi.stackexchange.com">vi.stackexchange.com</a>.</li>
+        <li>New to Neovim? Ask about usage and configuration at <a href="https://vi.stackexchange.com">vi.stackexchange.com</a>.</li>
       </ul>
     </div>
 

--- a/index.html
+++ b/index.html
@@ -136,7 +136,7 @@ redirect_from:
           or #neovim on <code>irc.libera.chat</code>.
         </li>
         <li>Contribute code, report bugs and request features at <a href="https://github.com/neovim/neovim">GitHub</a>.</li>
-        <li>New to Neovim? Ask about usage and configuration at <a href="https://vi.stackexchange.com">vi.stackexchange.com</a>.</li>
+        <li>Ask about usage and configuration at <a href="https://vi.stackexchange.com">vi.stackexchange.com</a>.</li>
       </ul>
     </div>
 

--- a/index.html
+++ b/index.html
@@ -131,8 +131,8 @@ redirect_from:
       <h2 id="chat">Chat</h2>
       <ul>
         <li><a href="https://twitter.com/Neovim" class="twitter-follow-button">Follow &#64;Neovim</a></li>
-        <li>Discuss the project on <a href="https://github.com/neovim/neovim/discussions">Github</a>, or
-          join live discussions at <a href="https://matrix.to/#/#neovim:matrix.org">#neovim:matrix.org</a>
+        <li>Discuss the project in <a href="https://github.com/neovim/neovim/discussions">GitHub Discussions</a>, or
+          chat in <a href="https://matrix.to/#/#neovim:matrix.org">#neovim:matrix.org</a>
           or #neovim on <code>irc.libera.chat</code>.
         </li>
         <li>Contribute code, report bugs and request features at <a href="https://github.com/neovim/neovim">GitHub</a>.</li>


### PR DESCRIPTION
Add link to Github discussions and more explicitly direct new users to vi.stackexchange.com