### PR TITLE
mention nvim tutor in index.html

### DIFF
--- a/index.html
+++ b/index.html
@@ -72,7 +72,7 @@ redirect_from:
         <li>
           Start with
           <a href="/doc/user/nvim.html#nvim-from-vim"><code>:help nvim-from-vim</code></a>
-          if you already use Vim.
+          if you already use Vim. If not, try <code>:Tutor</code>.
         </li>
       </ul>
 


### PR DESCRIPTION
Mention `:Tutor` on home page. This may actually be relevant for a different sections because this is also useful for people who are not coming from Vim. 