### PR TITLE
feat: enable BlueSky account verification

### DIFF
--- a/.well-known/atproto-did
+++ b/.well-known/atproto-did
@@ -1,0 +1,1 @@
+did:plc:635xovhsdw27inbgxukm3qtp

--- a/_config.yml
+++ b/_config.yml
@@ -29,3 +29,5 @@ exclude:
     - README.md
     - vendor/
     - sponsor-generator/
+
+include: ['.well-known']


### PR DESCRIPTION
This commit adds a 'https://neovim.io/.well-known/atproto-did' page with the content of a DID value taken from dedicated Neovim BlueSky account. With this page present, account will be able to use a `@neovim.io` handle which assures users that this is an "official" BlueSky account of Neovim team.

Details:
- The '.well-known' is a long established dedicated directory name for automated verification that certain domain belongs to a certain account on third-party site.
- The DID value of an account is a public information, so there should not be issues with it being present here in the open.