### PR TITLE
Add Custom 404 Page with GitHub Pages Support and Mobile Optimization

### DIFF
--- a/404.html
+++ b/404.html
@@ -15,6 +15,8 @@ canonical_url: /404.html
         <a href="/" class="btn">Go Home</a>
         <a href="/doc/" class="btn">Documentation</a>
       </div>
+      <div></div> <!-- empty second column -->
+    </div>
     </div>
   </div>
 </main>
@@ -26,7 +28,6 @@ canonical_url: /404.html
   color: #61ff00;
   font-family: 'SF Mono', 'Monaco', 'Inconsolata', 'Roboto Mono', 'Courier New', monospace;
   line-height: 1;
-  margin-bottom: 1rem;
 }
 
 .masthead h1 {

--- a/404.html
+++ b/404.html
@@ -2,11 +2,12 @@
 layout: default
 title: Page Not Found
 canonical_url: /404.html
+permalink: /404.html
 ---
 {% include nav.html %}
-<main class="front-section">
+<div style="padding: 3rem 0; min-height: 60vh; display: flex; align-items: center;">
   <div class="container">
-    <div class="masthead" style="max-width: 600px; margin: 0 auto; background-color: transparent;">
+    <div class="masthead" style="max-width: 600px; margin: 0 auto; background-color: transparent; text-align: center;">
       <div class="lead">404</div>
       <h1>Page Not Found</h1>
       <p class="light">The page you're looking for doesn't exist. It might have been moved, deleted, or you entered the wrong URL.</p>
@@ -16,15 +17,14 @@ canonical_url: /404.html
         <a href="/doc/" class="btn">Documentation</a>
       </div>
     </div>
-    </div>
   </div>
-</main>
+</div>
 
 <style>
 .masthead .lead {
   font-size: 8rem;
   font-weight: 700;
-  color:#22C55E;
+  color: #22C55E;
   font-family: 'SF Mono', 'Monaco', 'Inconsolata', 'Roboto Mono', 'Courier New', monospace;
   line-height: 1;
   margin-bottom: 0.5rem;
@@ -41,8 +41,10 @@ canonical_url: /404.html
 }
 
 .masthead .flex {
+  display: flex;
   justify-content: center;
   flex-wrap: wrap;
+  gap: 1rem;
 }
 
 @media (max-width: 525px) {
@@ -56,6 +58,7 @@ canonical_url: /404.html
   
   .masthead p {
     font-size: 1.1rem;
+    margin-bottom: 2rem;
   }
   
   .masthead .flex {
@@ -66,7 +69,11 @@ canonical_url: /404.html
   .masthead .btn {
     width: 100%;
     max-width: 280px;
+    text-align: center !important;
+    display: flex !important;
+    align-items: center !important;
+    justify-content: center !important;
+    padding: 0.75rem 1rem !important;
   }
 }
 </style>
-

--- a/404.html
+++ b/404.html
@@ -3,24 +3,22 @@ layout: default
 title: Page Not Found
 canonical_url: /404.html
 ---
-
 {% include nav.html %}
-
-<main class="hero">
+<main class="front-section">
   <div class="container">
     <div class="error-content">
       <div class="error-code">404</div>
-      <h1 class="error-title">Page Not Found</h1>
-      <p class="error-subtitle">The page you're looking for doesn't exist. It might have been moved, deleted, or you entered the wrong URL.</p>
+      <h1>Page Not Found</h1>
+      <p class="light">The page you're looking for doesn't exist. It might have been moved, deleted, or you entered the wrong URL.</p>
       
-      <div class="error-buttons">
-        <a href="/" class="btn btn-primary">Go Home</a>
-        <a href="/doc/" class="btn btn-secondary">Documentation</a>
+      <div class="flex error-buttons">
+        <a href="/" class="btn">Go Home</a>
+        <a href="/doc/" class="btn">Documentation</a>
       </div>
-
+      
       <div class="helpful-links">
         <h3>Popular Pages</h3>
-        <div class="links-grid">
+        <div class="col3">
           <a href="/" class="link-item">Home</a>
           <a href="/news/" class="link-item">News</a>
           <a href="/doc/" class="link-item">Documentation</a>
@@ -36,83 +34,65 @@ canonical_url: /404.html
 <style>
 .error-content {
   text-align: center;
-  padding: 4rem 0;
+  padding: 2rem 0;
   max-width: 600px;
   margin: 0 auto;
 }
 
 .error-code {
   font-size: 8rem;
-  font-weight: 700;
-  color: var(--primary-color, #22c55e);
-  font-family: 'SF Mono', 'Monaco', 'Inconsolata', 'Roboto Mono', 'Courier New', monospace;
+  font-weight: bold;
+  color: var(--accent-color);
+  font-family: var(--bs-font-monospace, monospace);
   line-height: 1;
   margin-bottom: 1rem;
 }
 
-.error-title {
+.error-content h1 {
   font-size: 2.5rem;
-  font-weight: 600;
   margin-bottom: 1rem;
 }
 
-.error-subtitle {
+.error-content p {
   font-size: 1.25rem;
-  opacity: 0.8;
   margin-bottom: 3rem;
-  line-height: 1.6;
 }
 
 .error-buttons {
-  display: flex;
-  gap: 1rem;
   justify-content: center;
   margin-bottom: 4rem;
   flex-wrap: wrap;
 }
 
 .helpful-links {
-  background: rgba(255, 255, 255, 0.03);
-  border: 1px solid rgba(255, 255, 255, 0.08);
-  border-radius: 8px;
+  background-color: var(--accent-bg-color);
+  border: 1px solid var(--border-color);
+  border-radius: 0.3em;
   padding: 2rem;
   text-align: left;
 }
 
 .helpful-links h3 {
-  color: var(--primary-color, #22c55e);
-  font-size: 1.25rem;
-  font-weight: 600;
-  margin-bottom: 1.5rem;
+  color: var(--accent-color);
   text-align: center;
-}
-
-.links-grid {
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
-  gap: 1rem;
+  margin-bottom: 1.5rem;
 }
 
 .link-item {
   display: block;
-  color: inherit;
-  text-decoration: none;
   padding: 0.75rem;
-  border-radius: 6px;
+  border-radius: 0.2em;
   border: 1px solid transparent;
-  transition: all 0.2s ease;
-  opacity: 0.8;
+  transition: all ease-in-out 140ms;
 }
 
-.link-item:hover {
-  color: var(--primary-color, #22c55e);
-  background: rgba(34, 197, 94, 0.05);
-  border-color: rgba(34, 197, 94, 0.2);
-  opacity: 1;
-  text-decoration: none;
+.link-item:hover,
+.link-item:focus {
+  background-color: var(--accent-bg-color);
+  border-color: var(--border-color);
 }
 
-@media (max-width: 768px) {
+@media (max-width: 525px) {
   .error-content {
     padding: 2rem 1rem;
   }
@@ -121,11 +101,11 @@ canonical_url: /404.html
     font-size: 6rem;
   }
   
-  .error-title {
+  .error-content h1 {
     font-size: 2rem;
   }
   
-  .error-subtitle {
+  .error-content p {
     font-size: 1.1rem;
   }
   
@@ -137,10 +117,6 @@ canonical_url: /404.html
   .error-buttons .btn {
     width: 100%;
     max-width: 280px;
-  }
-  
-  .links-grid {
-    grid-template-columns: 1fr;
   }
   
   .helpful-links {
@@ -158,7 +134,7 @@ if (typeof gtag !== 'undefined') {
   });
 }
 
-// Auto-redirect  after 3s
+// Auto-redirect after 3s
 const currentPath = window.location.pathname.toLowerCase();
 const redirects = {
   '/docs': '/doc/',

--- a/404.html
+++ b/404.html
@@ -6,121 +6,62 @@ canonical_url: /404.html
 {% include nav.html %}
 <main class="front-section">
   <div class="container">
-    <div class="error-content">
-      <div class="error-code">404</div>
+    <div class="masthead">
+      <div class="lead">404</div>
       <h1>Page Not Found</h1>
       <p class="light">The page you're looking for doesn't exist. It might have been moved, deleted, or you entered the wrong URL.</p>
       
-      <div class="flex error-buttons">
+      <div class="flex">
         <a href="/" class="btn">Go Home</a>
         <a href="/doc/" class="btn">Documentation</a>
-      </div>
-      
-      <div class="helpful-links">
-        <h3>Popular Pages</h3>
-        <div class="col3">
-          <a href="/" class="link-item">Home</a>
-          <a href="/news/" class="link-item">News</a>
-          <a href="/doc/" class="link-item">Documentation</a>
-          <a href="/sponsors/" class="link-item">Sponsors</a>
-          <a href="/charter/" class="link-item">Charter</a>
-          <a href="https://github.com/neovim/neovim" class="link-item">GitHub</a>
-        </div>
       </div>
     </div>
   </div>
 </main>
 
 <style>
-.error-content {
-  text-align: center;
-  padding: 2rem 0;
-  max-width: 600px;
-  margin: 0 auto;
-}
-
-.error-code {
+.masthead .lead {
   font-size: 8rem;
-  font-weight: bold;
   color: var(--accent-color);
-  font-family: var(--bs-font-monospace, monospace);
-  line-height: 1;
   margin-bottom: 1rem;
 }
 
-.error-content h1 {
+.masthead h1 {
   font-size: 2.5rem;
   margin-bottom: 1rem;
 }
 
-.error-content p {
+.masthead p {
   font-size: 1.25rem;
   margin-bottom: 3rem;
 }
 
-.error-buttons {
+.masthead .flex {
   justify-content: center;
-  margin-bottom: 4rem;
   flex-wrap: wrap;
 }
 
-.helpful-links {
-  background-color: var(--accent-bg-color);
-  border: 1px solid var(--border-color);
-  border-radius: 0.3em;
-  padding: 2rem;
-  text-align: left;
-}
-
-.helpful-links h3 {
-  color: var(--accent-color);
-  text-align: center;
-  margin-bottom: 1.5rem;
-}
-
-.link-item {
-  display: block;
-  padding: 0.75rem;
-  border-radius: 0.2em;
-  border: 1px solid transparent;
-  transition: all ease-in-out 140ms;
-}
-
-.link-item:hover,
-.link-item:focus {
-  background-color: var(--accent-bg-color);
-  border-color: var(--border-color);
-}
-
 @media (max-width: 525px) {
-  .error-content {
-    padding: 2rem 1rem;
-  }
-  
-  .error-code {
+  .masthead .lead {
     font-size: 6rem;
   }
   
-  .error-content h1 {
+  .masthead h1 {
     font-size: 2rem;
   }
   
-  .error-content p {
+  .masthead p {
     font-size: 1.1rem;
   }
   
-  .error-buttons {
+  .masthead .flex {
     flex-direction: column;
     align-items: center;
   }
   
-  .error-buttons .btn {
+  .masthead .btn {
     width: 100%;
     max-width: 280px;
-  }
-  
-  .helpful-links {
-    padding: 1.5rem;
   }
 }
 </style>

--- a/404.html
+++ b/404.html
@@ -1,0 +1,176 @@
+---
+layout: default
+title: Page Not Found
+canonical_url: /404.html
+---
+
+{% include nav.html %}
+
+<main class="hero">
+  <div class="container">
+    <div class="error-content">
+      <div class="error-code">404</div>
+      <h1 class="error-title">Page Not Found</h1>
+      <p class="error-subtitle">The page you're looking for doesn't exist. It might have been moved, deleted, or you entered the wrong URL.</p>
+      
+      <div class="error-buttons">
+        <a href="/" class="btn btn-primary">Go Home</a>
+        <a href="/doc/" class="btn btn-secondary">Documentation</a>
+      </div>
+
+      <div class="helpful-links">
+        <h3>Popular Pages</h3>
+        <div class="links-grid">
+          <a href="/" class="link-item">Home</a>
+          <a href="/news/" class="link-item">News</a>
+          <a href="/doc/" class="link-item">Documentation</a>
+          <a href="/sponsors/" class="link-item">Sponsors</a>
+          <a href="/charter/" class="link-item">Charter</a>
+          <a href="https://github.com/neovim/neovim" class="link-item">GitHub</a>
+        </div>
+      </div>
+    </div>
+  </div>
+</main>
+
+<style>
+.error-content {
+  text-align: center;
+  padding: 4rem 0;
+  max-width: 600px;
+  margin: 0 auto;
+}
+
+.error-code {
+  font-size: 8rem;
+  font-weight: 700;
+  color: var(--primary-color, #22c55e);
+  font-family: 'SF Mono', 'Monaco', 'Inconsolata', 'Roboto Mono', 'Courier New', monospace;
+  line-height: 1;
+  margin-bottom: 1rem;
+}
+
+.error-title {
+  font-size: 2.5rem;
+  font-weight: 600;
+  margin-bottom: 1rem;
+}
+
+.error-subtitle {
+  font-size: 1.25rem;
+  opacity: 0.8;
+  margin-bottom: 3rem;
+  line-height: 1.6;
+}
+
+.error-buttons {
+  display: flex;
+  gap: 1rem;
+  justify-content: center;
+  margin-bottom: 4rem;
+  flex-wrap: wrap;
+}
+
+.helpful-links {
+  background: rgba(255, 255, 255, 0.03);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: 8px;
+  padding: 2rem;
+  text-align: left;
+}
+
+.helpful-links h3 {
+  color: var(--primary-color, #22c55e);
+  font-size: 1.25rem;
+  font-weight: 600;
+  margin-bottom: 1.5rem;
+  text-align: center;
+}
+
+.links-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+  gap: 1rem;
+}
+
+.link-item {
+  display: block;
+  color: inherit;
+  text-decoration: none;
+  padding: 0.75rem;
+  border-radius: 6px;
+  border: 1px solid transparent;
+  transition: all 0.2s ease;
+  opacity: 0.8;
+}
+
+.link-item:hover {
+  color: var(--primary-color, #22c55e);
+  background: rgba(34, 197, 94, 0.05);
+  border-color: rgba(34, 197, 94, 0.2);
+  opacity: 1;
+  text-decoration: none;
+}
+
+@media (max-width: 768px) {
+  .error-content {
+    padding: 2rem 1rem;
+  }
+  
+  .error-code {
+    font-size: 6rem;
+  }
+  
+  .error-title {
+    font-size: 2rem;
+  }
+  
+  .error-subtitle {
+    font-size: 1.1rem;
+  }
+  
+  .error-buttons {
+    flex-direction: column;
+    align-items: center;
+  }
+  
+  .error-buttons .btn {
+    width: 100%;
+    max-width: 280px;
+  }
+  
+  .links-grid {
+    grid-template-columns: 1fr;
+  }
+  
+  .helpful-links {
+    padding: 1.5rem;
+  }
+}
+</style>
+
+<script>
+// Track 404 errors 
+if (typeof gtag !== 'undefined') {
+  gtag('event', 'page_view', {
+    page_title: '404 - Page Not Found',
+    page_location: window.location.href
+  });
+}
+
+// Auto-redirect  after 3s
+const currentPath = window.location.pathname.toLowerCase();
+const redirects = {
+  '/docs': '/doc/',
+  '/documentation': '/doc/',
+  '/github': 'https://github.com/neovim/neovim',
+  '/repo': 'https://github.com/neovim/neovim'
+};
+
+if (redirects[currentPath]) {
+  console.log(`Redirecting ${currentPath} to ${redirects[currentPath]} in 3 seconds...`);
+  setTimeout(() => {
+    window.location.href = redirects[currentPath];
+  }, 3000);
+}
+</script>

--- a/404.html
+++ b/404.html
@@ -6,7 +6,7 @@ canonical_url: /404.html
 {% include nav.html %}
 <main class="front-section">
   <div class="container">
-    <div class="masthead">
+    <div class="masthead" style="max-width: 600px; margin: 0 auto; background-color: transparent;">
       <div class="lead">404</div>
       <h1>Page Not Found</h1>
       <p class="light">The page you're looking for doesn't exist. It might have been moved, deleted, or you entered the wrong URL.</p>
@@ -22,7 +22,10 @@ canonical_url: /404.html
 <style>
 .masthead .lead {
   font-size: 8rem;
-  color: var(--accent-color);
+  font-weight: 700;
+  color: #61ff00;
+  font-family: 'SF Mono', 'Monaco', 'Inconsolata', 'Roboto Mono', 'Courier New', monospace;
+  line-height: 1;
   margin-bottom: 1rem;
 }
 
@@ -66,28 +69,3 @@ canonical_url: /404.html
 }
 </style>
 
-<script>
-// Track 404 errors 
-if (typeof gtag !== 'undefined') {
-  gtag('event', 'page_view', {
-    page_title: '404 - Page Not Found',
-    page_location: window.location.href
-  });
-}
-
-// Auto-redirect after 3s
-const currentPath = window.location.pathname.toLowerCase();
-const redirects = {
-  '/docs': '/doc/',
-  '/documentation': '/doc/',
-  '/github': 'https://github.com/neovim/neovim',
-  '/repo': 'https://github.com/neovim/neovim'
-};
-
-if (redirects[currentPath]) {
-  console.log(`Redirecting ${currentPath} to ${redirects[currentPath]} in 3 seconds...`);
-  setTimeout(() => {
-    window.location.href = redirects[currentPath];
-  }, 3000);
-}
-</script>

--- a/404.html
+++ b/404.html
@@ -15,7 +15,6 @@ canonical_url: /404.html
         <a href="/" class="btn">Go Home</a>
         <a href="/doc/" class="btn">Documentation</a>
       </div>
-      <div></div> <!-- empty second column -->
     </div>
     </div>
   </div>
@@ -25,9 +24,10 @@ canonical_url: /404.html
 .masthead .lead {
   font-size: 8rem;
   font-weight: 700;
-  color: #61ff00;
+  color:#22C55E;
   font-family: 'SF Mono', 'Monaco', 'Inconsolata', 'Roboto Mono', 'Courier New', monospace;
   line-height: 1;
+  margin-bottom: 0.5rem;
 }
 
 .masthead h1 {

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -23,7 +23,11 @@
 
     <link href="/css/main.css" rel="stylesheet">
     <link href="/css/neovim-hi.css" rel="stylesheet">
+    {% unless page.url == "/404.html" %}
     <link rel="canonical" href="{{ site.url }}{% if page.canonical_url %}{{ page.canonical_url }}{% else %}{{ page.url }}{% endif %}" />
+    {% else %}
+    <meta name="robots" content="noindex">
+    {% endunless %}
   </head>
 
   <body>


### PR DESCRIPTION
## Summary
Adds a custom 404 page for GitHub Pages with responsive design and mobile button alignment fixes.

## Changes Made
### 404 Page (`404.html`)
- Added custom 404 page with site styling and GitHub Pages permalink support
- Fixed mobile button text centering and responsive layout
- Added flexbox layout with proper spacing

### Layout Updates (`_layouts/default.html`)
- Added conditional canonical links for SEO
- Added noindex meta tag for 404 page

## Features
- GitHub Pages compatible with proper permalink structure
- Mobile optimized responsive design
- SEO friendly with proper meta tag handling
- Consistent with site theme and typography

## Testing
- [ ] 404 page works on desktop and mobile
- [ ] Non-existent routes redirect to custom 404 page
- [ ] Button alignment is correct on all screen sizes
<img width="1678" height="799" alt="2025-09-15_14-43" src="https://github.com/user-attachments/assets/3b2a16a6-9a00-4494-8579-bd7605bb2ac1" />
