### PR TITLE
ci: use peaceiris/actions-gh-pages

### DIFF
--- a/.github/workflows/hugo.yaml
+++ b/.github/workflows/hugo.yaml
@@ -45,9 +45,11 @@ jobs:
         with:
           submodules: recursive
           fetch-depth: 0
+      # TODO: is this needed?
       - name: Setup Pages
         id: pages
         uses: actions/configure-pages@v5
+      # TODO: is this needed?
       - name: Install Node.js dependencies
         run: "[[ -f package-lock.json || -f npm-shrinkwrap.json ]] && npm ci || true"
       - name: Build with Hugo
@@ -76,4 +78,7 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: peaceiris/actions-gh-pages@v4
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./public


### PR DESCRIPTION
Problem:
`actions/deploy-pages` explicitly excludes dot-prefixed directories, so `.well-known/atproto-did` is not published even though it definitely exists in `public/`.

ref https://github.com/actions/deploy-pages/issues/203 
fix https://github.com/neovim/neovim.github.io/issues/397

Solution:
Use `peaceiris/actions-gh-pages` instead.