### PR TITLE
fix: 404.html

### DIFF
--- a/layouts/404.html
+++ b/layouts/404.html
@@ -1,9 +1,4 @@
----
-layout: default
-title: Page Not Found
-canonical_url: /404.html
-permalink: /404.html
----
+{{ define "main" }}
 
 <div style="padding: 3rem 0; min-height: 60vh; display: flex; align-items: center;">
   <div class="container">
@@ -78,3 +73,5 @@ permalink: /404.html
     }
   }
 </style>
+
+{{ end }}


### PR DESCRIPTION
Problem:
`content/404.html` generates `404/index.html`, which github will not automatically use as the 404 page.

Solution:
Move to layouts/.