### PR TITLE
fix: empty RSS feed link on news page

### DIFF
--- a/hugo.toml
+++ b/hugo.toml
@@ -22,6 +22,7 @@ title = 'Neovim'
     name = "Neovim Newsletter"
     authors = "Neovim Community"
     url = "/news"
+    feed = "/news.xml"
 
 [markup]
   [markup.goldmark]


### PR DESCRIPTION
Related to 4ce26f11b076edbaf720116413971f2535ab4051

Related to #400