### PR TITLE
feat: add rss link to document head for autodiscovery

### DIFF
--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -32,6 +32,7 @@
     {{ else }}
     <meta name="robots" content="noindex">
     {{ end }}
+    <link href="{{ .Site.BaseURL }}.{{ .Site.Params.news.feed }}" rel="alternate" title="{{ .Site.Params.news.name }}" type="application/rss+xml">
 </head>
 
 <body>


### PR DESCRIPTION
With this link, a rss reader can be pointed to any url of the site and it will find the feed.

(In order to not end up with a double slash in the path when constructing the absolute feed url out of `.Site.BaseURL` and `.Site.Params.news.feed`, I've inserted a dot in-between. In a http request, double slashes will be transmitted as-is, potentially causing issues, whereas dot segments are to be resolved by the client beforehand (as per rfc3986). It's the little things… :-))