### PR TITLE
fix: sync_docs.sh missing "/" in URL paths

### DIFF
--- a/content/doc2/build.md
+++ b/content/doc2/build.md
@@ -13,7 +13,7 @@ type: page
 3. `cd neovim`
     - If you want the **stable release**, also run `git checkout stable`.
 4. `make CMAKE_BUILD_TYPE=RelWithDebInfo`
-    - If you want to install to a custom location, set `CMAKE_INSTALL_PREFIX`. See also [../install](./../install#install-from-source).
+    - If you want to install to a custom location, set `CMAKE_INSTALL_PREFIX`. See also [../install/](./../install/#install-from-source).
     - On BSD, use `gmake` instead of `make`.
     - To build on Windows, see the [Building on Windows](#building-on-windows) section. _MSVC (Visual Studio) is recommended._
 5. `sudo make install`

--- a/content/doc2/install.md
+++ b/content/doc2/install.md
@@ -57,7 +57,7 @@ Several Neovim GUIs are available from scoop (extras): [scoop.sh/#/apps?q=neovim
 
 ### Pre-built archives
 
-0. If you are missing `VCRUNTIME140.dll`, install the [Visual Studio 2015 C++ redistributable](https://support.microsoft.com/en-us/kb/2977003) (choose x86_64 or x86 depending on your system).
+0. If you are missing `VCRUNTIME170.dll`, install the [Visual Studio C++ redistributable](https://learn.microsoft.com/en-us/cpp/windows/latest-supported-vc-redist) (choose x86_64 or x86 depending on your system).
 1. Choose a package (**nvim-winXX.zip**) from the [releases page](https://github.com/neovim/neovim/releases).
 2. Unzip the package. Any location is fine, administrator privileges are _not_ required.
     - `$VIMRUNTIME` will be set to that location automatically.
@@ -405,7 +405,7 @@ or [from the ports tree](https://cvsweb.openbsd.org/cgi-bin/cvsweb/ports/editors
 Install from source
 ===================
 
-If a package is not provided for your platform, you can build Neovim from source. See [../build](./../build) for details.  If you have the [prerequisites](./../build#build-prerequisites) then building is easy:
+If a package is not provided for your platform, you can build Neovim from source. See [../build/](./../build/) for details.  If you have the [prerequisites](./../build/#build-prerequisites) then building is easy:
 
     make CMAKE_BUILD_TYPE=Release
     sudo make install

--- a/sync_docs.sh
+++ b/sync_docs.sh
@@ -29,12 +29,12 @@ EOF
 curl -Lo content/doc2/build.md https://raw.githubusercontent.com/neovim/neovim/refs/heads/master/BUILD.md
 add_frontmatter content/doc2/build.md "Build"
 # Replace INSTALL.md hyperlinks with "./install".
-sed -i '' 's/INSTALL\.md/\.\.\/install/g' content/doc2/build.md
+sed -i '' 's/INSTALL\.md/\.\.\/install\//g' content/doc2/build.md
 
 curl -Lo content/doc2/install.md https://raw.githubusercontent.com/neovim/neovim/refs/heads/master/INSTALL.md
 add_frontmatter content/doc2/install.md "Install"
 # Replace BUILD.md hyperlinks with "./build".
-sed -i '' 's/BUILD\.md/\.\.\/build/g' content/doc2/install.md
+sed -i '' 's/BUILD\.md/\.\.\/build\//g' content/doc2/install.md
 
 git add content/doc2/
 git commit -m 'update content/doc2/ files from neovim/neovim repo'


### PR DESCRIPTION
Problem:
HTTP path "/foo" redirects to "/foo/", and this is reported by tools such as Algolia docsearch.

Solution:
Fix the paths. Update `sync_docs.sh`.