### PR TITLE
fix: horizontal overflow in doc/{build,install} on mobile devices

### DIFF
--- a/static/css/main.css
+++ b/static/css/main.css
@@ -217,6 +217,11 @@ samp {
     grid-template-columns: 1fr;
   }
 }
+
+.col-wide {
+  max-width: 90vw;
+}
+
 /*
  * Navbar
  *


### PR DESCRIPTION
Problem:
div.col-wide does not have a max-width set which makes the text overflow
on small-width devices.

Solution:
Set the max-width to 90vw. The parent container has a width of 100% and
x-padding of `1.5rem * .5`, but that makes it needlessly complicated and
depends on a bootstrap variable.

Closes: #417

Screenshot in Chrome devtools:

<img width="442" height="931" alt="image" src="https://github.com/user-attachments/assets/52bf586a-6c09-4d71-b9c2-81875f1932a2" />

