### PR TITLE
refactor: move more content to Markdown

### DIFF
--- a/content/_index.md
+++ b/content/_index.md
@@ -3,4 +3,74 @@ title: Home
 active: Home
 redirect_from:
   - /development-wiki/
+params:
+  impressions:
+    - quote: Neovim is exactly what it claims to be. It fixes every issue I have with Vim.
+      name: Geoff Greer
+      link: http://geoff.greer.fm/2015/01/15/why-neovim-is-better-than-vim/
+    - quote: Full-screen Neovim looks cool as hell!
+      name: DHH
+      link: https://x.com/dhh/status/1764465909316583659
+    - quote: A nice looking website, that’s one thing Neovim did right.
+      name: Bram Moolenaar
+      link: https://www.binpress.com/vim-creator-bram-moolenaar-interview/
+  faq:
+    - question: What is the project status?
+      answer: |
+        The current [stable release](https://github.com/neovim/neovim/releases/latest)
+        version is `0.11` ([RSS](https://github.com/neovim/neovim/tags.atom)).
+        See the [roadmap](/roadmap/) for progress and plans.
+    - question: Is Neovim trying to turn Vim into an IDE?
+      answer: |
+        With 30% less source-code than Vim, the [vision](/charter/)
+        of Neovim is to enable new applications without compromising Vim's
+        traditional roles.
+    - question: Will Neovim deprecate Vimscript?
+      answer: |
+        No. Lua is built-in, but Vimscript is supported with the
+        [world's most advanced Vimscript engine](/doc/user/api.html#nvim_parse_expression()).
+    - question: Which plugins does Neovim support?
+      answer: |
+        Vim 8.x plugins and
+        [much more](https://github.com/neovim/neovim/wiki/Related-projects).
 ---
+
+## Features
+
+### Extensible
+
+- API is first-class: [discoverable](/doc/user/api.html#api-mapping),
+  [versioned](/doc/user/api.html#api-contract),
+  [documented](/doc/user/api.html#api-global).
+- [MessagePack](http://msgpack.org/) structured communication enables
+  extensions in any language.
+- Remote plugins run as co-processes, safely and asynchronously.
+- GUIs, IDEs, web browsers can `--embed` Neovim as an editor or script
+  host.
+- [Lua plugins](/doc/user/lua.html) are easy to create just like
+  Vimscript plugins. Your config can live in `init.lua`!
+- AST-producing [parsing engine](https://tree-sitter.github.io/) enables
+  faster, more accurate syntax highlighting, code navigation,
+  refactoring, text objects, and motions.
+
+### Usable
+
+- Strong [defaults](/doc/user/vim_diff.html#nvim-defaults) including a
+  unique, minimalist colorscheme.
+- Builtin [LSP client](/doc/user/lsp.html) for semantic code inspection
+  and refactoring (go-to definition, "find references", format, ...).
+- Client-server architecture allows you to
+  [:detach](/doc/user/gui.html#%3Adetach) the UI and keep the editor
+  session running (like tmux). Attach multiple UIs to any Nvim session.
+- No "Press ENTER" messages (Nvim 0.12 feature).
+- Works the same everywhere: one build-type, one command.
+- Modern terminal features such as cursor styling, focus events,
+  bracketed paste.
+- Builtin [:terminal](https://www.youtube.com/watch?v=xZbMVj9XSUo) set
+  the standard for "TTY as a basic component".
+
+### Drop-in Vim
+
+- Fully compatible with Vim's editing model and Vimscript v1.
+- Start with [`:help nvim-from-vim`](/doc/user/nvim.html#nvim-from-vim)
+  if you already use Vim. If not, try `:Tutor`.

--- a/content/_misc/whatisnvim.md
+++ b/content/_misc/whatisnvim.md
@@ -1,0 +1,26 @@
+---
+title: whatisnvim
+headless: true
+---
+
+### What is Neovim?
+
+Neovim is a Vim-based text editor engineered for
+[extensibility](https://github.com/neovim/neovim/wiki/Related-projects#api-clients)
+and [usability](https://neovim.io/doc/user/vim_diff.html#nvim-features),
+to encourage new applications and
+[contributions](https://github.com/neovim/neovim/blob/master/CONTRIBUTING.md#getting-started).
+
+- [Vision](/charter/)
+- [Roadmap](/roadmap/)
+
+### Discuss
+
+Visit
+[#neovim:matrix.org](https://app.element.io/#/room/#neovim:matrix.org)
+or #neovim on irc.libera.chat to chat with the team.
+
+<script>!function(d,s,id){var js,fjs=d.getElementsByTagName(s)[0],p=/^http:/.test(d.location)?'http':'https';if(!d.getElementById(id)){js=d.createElement(s);js.id=id;js.src=p+'://platform.twitter.com/widgets.js';fjs.parentNode.insertBefore(js,fjs);}}(document, 'script', 'twitter-wjs');</script>
+<a href="https://twitter.com/Neovim" class="twitter-follow-button" data-show-count="false" data-size="large">Follow @Neovim on X</a><br>
+[Mastodon](https://hachyderm.io/@neovim)\
+[Bluesky](https://bsky.app/profile/neovim.io)

--- a/layouts/_partials/whatisnvim.html
+++ b/layouts/_partials/whatisnvim.html
@@ -1,28 +1,3 @@
-<h3>What is Neovim?</h3>
-<p>
-  Neovim is a Vim-based text editor engineered for
-  <a href="https://github.com/neovim/neovim/wiki/Related-projects#api-clients">extensibility</a>
-  and
-  <a href="https://neovim.io/doc/user/vim_diff.html#nvim-features">usability</a>,
-  to encourage new applications and
-  <a href="https://github.com/neovim/neovim/blob/master/CONTRIBUTING.md#getting-started">contributions</a>.
-
-  <ul>
-    <li><a href="/charter/">Vision</a></li>
-    <li><a href="/roadmap/">Roadmap</a></li>
-  </ul>
-</p>
-
-<h3>Discuss</h3>
-<p>
-  Visit <a href="https://app.element.io/#/room/#neovim:matrix.org">#neovim:matrix.org</a>
-  or #neovim on irc.libera.chat to chat with the team.
-</p>
-<p style="vertical-align: middle;">
-<a href="https://twitter.com/Neovim" class="twitter-follow-button" data-show-count="false" data-size="large">Follow @Neovim on X</a>
-  <script>!function(d,s,id){var js,fjs=d.getElementsByTagName(s)[0],p=/^http:/.test(d.location)?'http':'https';if(!d.getElementById(id)){js=d.createElement(s);js.id=id;js.src=p+'://platform.twitter.com/widgets.js';fjs.parentNode.insertBefore(js,fjs);}}(document, 'script', 'twitter-wjs');</script>
-  <br>
-  <a rel="me" href="https://hachyderm.io/@neovim">Mastodon</a>
-  <br>
-  <a href="https://bsky.app/profile/neovim.io">Bluesky</a>
-</p>
+{{ with site.GetPage "_misc/whatisnvim" }}
+  {{ .Content }}
+{{ end }}

--- a/layouts/home.html
+++ b/layouts/home.html
@@ -10,68 +10,7 @@
 <section class="front-section">
     <div class="container golden-grid">
         <div class="col-wide">
-            <h2>Features</h2>
-
-            <h3>Extensible</h3>
-            <ul>
-                <li>
-                    API is first-class:
-                    <a href="/doc/user/api.html#api-mapping">discoverable</a>,
-                    <a href="/doc/user/api.html#api-contract">versioned</a>,
-                    <a href="/doc/user/api.html#api-global">documented</a>.
-                </li>
-                <li>
-                    <a href="http://msgpack.org/">MessagePack</a> structured communication
-                    enables extensions in any language.
-                </li>
-                <li>
-                    Remote plugins run as co-processes, safely and asynchronously.
-                </li>
-                <li>
-                    GUIs, IDEs, web browsers can <code>--embed</code> Neovim as an editor or script host.
-                </li>
-                <li>
-                    <a href="/doc/user/lua.html">Lua plugins</a> are easy to create just like Vimscript plugins.
-                    Your config can live in <code>init.lua</code>!
-                </li>
-                <li>
-                    AST-producing <a href="https://tree-sitter.github.io/">parsing engine</a>
-                    enables faster, more accurate syntax highlighting, code navigation,
-                    refactoring, text objects, and motions.
-                </li>
-            </ul>
-
-            <h3>Usable</h3>
-            <ul>
-                <li>Strong <a href="/doc/user/vim_diff.html#nvim-defaults">defaults</a> including a unique, minimalist
-                    colorscheme.</li>
-                <li>
-                    Builtin <a href="/doc/user/lsp.html">LSP client</a> for
-                    semantic code inspection and refactoring (go-to definition, "find references", format, …).
-                </li>
-                <li>
-                    Client-server architecture allows you to <a href="/doc/user/gui.html#%3Adetach">:detach</a>
-                    the UI and keep the editor session running (like tmux). Attach multiple UIs to any Nvim session.
-                </li>
-                <li>No "Press ENTER" messages (Nvim 0.12 feature).</li>
-                <li>Works the same everywhere: one build-type, one command.</li>
-                <li>Modern terminal features such as cursor styling, focus events, bracketed paste.</li>
-                <li>Builtin <a href="https://www.youtube.com/watch?v=xZbMVj9XSUo">:terminal</a> set the standard for
-                    "TTY as a basic component".</li>
-            </ul>
-
-            <h3>Drop-in Vim</h3>
-            <ul>
-                <li>
-                    Fully compatible with Vim's editing model and Vimscript v1.
-                </li>
-                <li>
-                    Start with
-                    <a href="/doc/user/nvim.html#nvim-from-vim"><code>:help nvim-from-vim</code></a>
-                    if you already use Vim. If not, try <code>:Tutor</code>.
-                </li>
-            </ul>
-
+        {{ .Content }}
         </div>
         <div class="col-narrow">
             <h2 id="sponsors-header"><a href="/sponsors/">Sponsors</a></h2>
@@ -127,18 +66,9 @@
                 <p><a href="/news/archive/">More…</a></p>
 
                 <h2>Impressions</h2>
-                <p>
-                    "Neovim is exactly what it claims to be. It fixes every issue I have with Vim."
-                    <a href="http://geoff.greer.fm/2015/01/15/why-neovim-is-better-than-vim/">—Geoff Greer</a>
-                </p>
-                <p>
-                    "Full-screen Neovim looks cool as hell!"
-                    <a href="https://x.com/dhh/status/1764465909316583659">—DHH</a>
-                </p>
-                <p>
-                    "A nice looking website, that’s one thing Neovim did right."
-                    <a href="https://www.binpress.com/vim-creator-bram-moolenaar-interview/">—Bram Moolenaar</a>
-                </p>
+                {{ range .Params.impressions }}
+                <p>"{{ .quote | markdownify }}" <a href="{{ .link }}">—{{ .name }}</a></p>
+                {{ end }}
             </div>
         </div>
     </div>
@@ -184,27 +114,10 @@
         <div>
             <h2 id="faqs">FAQ</h2>
             <dl class="faqs">
-                <dt>What is the project status?</dt>
-                <dd>
-                    The current <a href="https://github.com/neovim/neovim/releases/latest">stable release</a>
-                    version is <code>0.11</code> (<a href="https://github.com/neovim/neovim/tags.atom">RSS</a>).
-                    See the <a href="roadmap/">roadmap</a> for progress and plans.
-                </dd>
-
-                <dt>Is Neovim trying to turn Vim into an IDE?</dt>
-                <dd>With 30% less source-code than Vim, the <a href="charter/">vision</a>
-                    of Neovim is to enable new applications without compromising Vim's
-                    traditional roles. </dd>
-
-                <dt>Will Neovim deprecate Vimscript?</dt>
-                <dd>
-                    No. Lua is built-in, but Vimscript is supported with the
-                    <a href="/doc/user/api.html#nvim_parse_expression()">world's most advanced Vimscript engine</a>.
-                </dd>
-
-                <dt>Which plugins does Neovim support?</dt>
-                <dd>Vim 8.x plugins and <a href="https://github.com/neovim/neovim/wiki/Related-projects">much more</a>.
-                </dd>
+                {{ range .Params.faq }}
+                <dt>{{ .question | markdownify }}</dt>
+                <dd>{{ .answer | markdownify }}</dd>
+                {{ end }}
             </dl>
         </div>
         <div>


### PR DESCRIPTION
Problem:
Maintaining text in HTML is cumbersome and Hugo supports Markdown.

Solution:
Move textual content to Markdown.

Also moved `layouts/index.html` to `layouts/home.html` as index.html will be deprecated eventually (missed it in earlier PR)