### PR TITLE
fix(gendoc): error if errors or invalid links found

### DIFF
--- a/gendoc.lua
+++ b/gendoc.lua
@@ -79,9 +79,17 @@ local function main()
   local docdir = joinpath(srcdir, 'runtime/doc')
   local usercontent = 'content/doc/user'
 
+  vim.cmd(('helptags ++t %s'):format(docdir))
   -- Generate html pages from the Vimdoc files
   local genhelp = dofile(joinpath(nvim_repo, 'src/gen/gen_help_html.lua'))
-  genhelp.gen(docdir, usercontent, nil, commit_hash(srcdir))
+  local res = genhelp.gen(docdir, usercontent, nil, commit_hash(srcdir))
+
+  if res.err_count > 0 or #res.invalid_links > 0 then
+    error(('Error generating pages: err_count: %d, #invalid_links: %d'):format(
+      res.err_count,
+      res.invalid_links
+    ))
+  end
 
   local out_install = 'content/doc/install.md'
   sys({ 'hugo', 'new', 'content', '--force', out_install })


### PR DESCRIPTION
Problem:
- it fails silently, so not getting caught in CI.
- may need to run :helptags ALL or something like that

Solution:
- error() on errors or invalid links
- run helptags ++t <nvim_repo>/runtime/doc beforehand

Reported here: https://github.com/neovim/neovim.github.io/pull/437#issuecomment-3947773162
