### PR TITLE
Move news to content/news

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,13 @@ just do the following:
 
 Notes:
 
+- Create new blog posts (news items) using the command:
+  ```bash
+  hugo new content content/news/<filename>.md
+  ```
+  The filename won't show up on the site -- the page url will be in the form of
+  `/news/2026/12/` where 2026 is the year and 12 the month, as defined in the
+  front matter.
 - Site search (for `:help` docs) is served by [Algolia Docsearch](https://docsearch.algolia.com/).
     - The javascript and UI container were setup in [this commit](https://github.com/neovim/neovim.github.io/commit/ce9aef12eb1c98135965e3a9c5c792bf9e506a76).
     - The docs pages don't use the layout so they also need to [manually include](https://github.com/neovim/neovim/pull/23839) the javascript and define a UI container.

--- a/content/news/2014-06-06-june-newsletter.md
+++ b/content/news/2014-06-06-june-newsletter.md
@@ -1,7 +1,7 @@
 ---
 title: "Newsletter #1 - A New Hope"
+date: 2014-06-06
 category: newsletter
-permalink: /news/2014/06/
 ---
 
 Welcome to the first newsletter for Neovim, a project that hopes to give a new

--- a/content/news/2014-07-04-july-newsletter.md
+++ b/content/news/2014-07-04-july-newsletter.md
@@ -1,7 +1,7 @@
 ---
 title: "Newsletter #2 - Perchance to Dream"
+date: 2014-07-04
 category: newsletter
-permalink: /news/2014/07/
 ---
 
 Welcome to the second monthly newsletter for Neovim, the project that dreams to

--- a/content/news/2014-09-06-september-newsletter.md
+++ b/content/news/2014-09-06-september-newsletter.md
@@ -1,7 +1,9 @@
 ---
 title: "Newsletter #3 - Better Late than Never"
+date: 2014-09-06
 category: newsletter
-permalink: /news/2014/sept/
+aliases:
+  - /news/2014/sept/
 ---
 
 Welcome to the third (and delayed) newsletter for Neovim, the project that aims

--- a/content/news/2014-11-07-november-newsletter.md
+++ b/content/news/2014-11-07-november-newsletter.md
@@ -1,7 +1,9 @@
 ---
 title: "Newsletter #4 - Thanksvimming Day"
+date: 2014-11-07
 category: newsletter
-permalink: /news/2014/nov/
+aliases:
+  - /news/2014/nov/
 ---
 
 > The way to "win" at open source is to be consistent and steady.

--- a/content/news/2015-04-03-newsletter.md
+++ b/content/news/2015-04-03-newsletter.md
@@ -1,7 +1,9 @@
 ---
 title: "Newsletter #5 - Out of the Box"
+date: 2015-04-03
 category: newsletter
-permalink: /news/2015/april/
+aliases:
+  - /news/2015/april/
 ---
 
 > Outstanding communication and handling of bugs from Neovim. Exemplary FOSS

--- a/content/news/2015-12-09-newsletter.md
+++ b/content/news/2015-12-09-newsletter.md
@@ -1,7 +1,9 @@
 ---
 title: "Newsletter #6 - Ship it!"
+date: 2015-12-09
 category: newsletter
-permalink: /news/2015/december/
+aliases:
+  - /news/2015/december/
 ---
 
 Welcome to the sixth newsletter for Neovim, a project that aims to improve Vim

--- a/content/news/2016-11-01-newsletter.md
+++ b/content/news/2016-11-01-newsletter.md
@@ -1,7 +1,7 @@
 ---
 title: "Newsletter #7 - Summer of Road"
+date: 2016-11-01
 category: newsletter
-permalink: /news/2016/11/
 ---
 
 It's time for the Neovim newsletter! Skip to the [Fun](#fun-without-smile) and

--- a/content/news/2017-12-16-newsletter.md
+++ b/content/news/2017-12-16-newsletter.md
@@ -1,7 +1,7 @@
 ---
 title: "Newsletter #8 - Open up the Windows"
+date: 2017-12-16
 category: newsletter
-permalink: /news/2017/12/
 ---
 
 What is Neovim?

--- a/content/news/2019-03-17-newsletter.md
+++ b/content/news/2019-03-17-newsletter.md
@@ -1,7 +1,9 @@
 ---
 title: "Google Summer of Code 2019"
+date: 2019-03-17
 category: newsletter
-permalink: /news/gsoc-2019
+aliases:
+  - /news/gsoc-2019
 ---
 
 Neovim was again accepted into the Google Summer of Code program.

--- a/content/news/2020-04-14-newsletter.md
+++ b/content/news/2020-04-14-newsletter.md
@@ -1,7 +1,7 @@
 ---
 title: "Newsletter #9 - Three's company"
+date: 2020-04-14
 category: newsletter
-permalink: /news/2020/04/
 ---
 
 What is Neovim?

--- a/content/news/2020-10-28-newsletter.md
+++ b/content/news/2020-10-28-newsletter.md
@@ -1,7 +1,7 @@
 ---
 title: "Newsletter #10 - Neovim v0.4.4"
+date: 2020-10-28
 category: newsletter
-permalink: /news/2020/10/
 ---
 
 What is Neovim?

--- a/content/news/2021-07-12-newsletter.md
+++ b/content/news/2021-07-12-newsletter.md
@@ -1,7 +1,7 @@
 ---
 title: "Neovim News #11 - The Christmas Issue"
+date: 2021-07-12
 category: newsletter
-permalink: /news/2021/07
 ---
 
 > The _real_ 0.5 was the friends we made along the way

--- a/content/news/2022-04-26-newsletter.md
+++ b/content/news/2022-04-26-newsletter.md
@@ -1,7 +1,7 @@
 ---
 title: "Neovim News #12 - What's New In Neovim 0.7"
+date: 2022-04-26
 category: newsletter
-permalink: /news/2022/04
 ---
 
 > Original article: <https://gpanders.com/blog/whats-new-in-neovim-0-7>

--- a/content/news/2022-12-31-newsletter.md
+++ b/content/news/2022-12-31-newsletter.md
@@ -1,7 +1,7 @@
 ---
 title: "What Neovim shipped in 2022"
+date: 2022-12-31
 category: newsletter
-permalink: /news/2022/12
 ---
 
 

--- a/content/news/2023-08-09-bram.md
+++ b/content/news/2023-08-09-bram.md
@@ -1,7 +1,7 @@
 ---
 title: "Vim Boss"
+date: 2023-08-09
 category: newsletter
-permalink: /news/2023/08
 ---
 
 Bram is one of my heroes. That's literal and recursive: when I say it,

--- a/content/news/2024-05-16-news.md
+++ b/content/news/2024-05-16-news.md
@@ -1,7 +1,7 @@
 ---
 title: "Neovim 0.10"
+date: 2024-05-16
 category: newsletter
-permalink: /news/2024/05
 ---
 
 Nvim 0.10 was released.

--- a/content/news/2025-02-28-gsoc.md
+++ b/content/news/2025-02-28-gsoc.md
@@ -1,7 +1,7 @@
 ---
 title: "Google Summer of Code 2025"
+date: 2025-02-28
 category: newsletter
-permalink: /news/2025/02
 ---
 
 Neovim is participating in [Google Summer of Code 2025](https://summerofcode.withgoogle.com/programs/2025/organizations/neovim)!

--- a/content/news/2025-03-22-news.md
+++ b/content/news/2025-03-22-news.md
@@ -1,7 +1,7 @@
 ---
 title: "Neovim 0.11"
+date: 2025-03-22
 category: newsletter
-permalink: /news/2025/03
 ---
 
 Nvim 0.11 was released.

--- a/content/news/2026-02-21-gsoc.md
+++ b/content/news/2026-02-21-gsoc.md
@@ -1,7 +1,7 @@
 ---
 title: "Google Summer of Code 2026"
+date: 2026-02-21
 category: newsletter
-permalink: /news/2026/02
 ---
 
 Neovim is participating in [Google Summer of Code 2026](https://summerofcode.withgoogle.com/programs/2026/organizations/neovim)!

--- a/content/news/_index.md
+++ b/content/news/_index.md
@@ -1,5 +1,4 @@
 ---
 title: News
 active: News
-layout: single
 ---

--- a/content/news/archive.md
+++ b/content/news/archive.md
@@ -2,4 +2,5 @@
 title: News archive
 active: News
 layout: list
+url: /news/archive/
 ---

--- a/content/posts/_index.md
+++ b/content/posts/_index.md
@@ -1,6 +1,0 @@
----
-title: News
-outputs:
-  - html
-  - rss
----

--- a/hugo.toml
+++ b/hugo.toml
@@ -6,7 +6,7 @@ title = 'Neovim'
   date = [":filename", ":default"]
 
 [permalinks]
-  posts = "/news/:year/:month/"
+  news = "/:section/:year/:month/"
 
 [outputs]
   section = ["html", "rss"]

--- a/layouts/news/list.html
+++ b/layouts/news/list.html
@@ -5,7 +5,7 @@
 
             <h1>{{ .Title }}</h1>
 
-            {{ range sort (where .Site.RegularPages "Section" "posts") "Date" "asc" }}
+            {{ range (sort (where .CurrentSection.Pages "Layout" "ne" "list") "Date" "asc") }}
             <h3><a href="{{ .RelPermalink }}">{{ .Title }}</a></h3>
             {{ end }}
 

--- a/layouts/news/section.html
+++ b/layouts/news/section.html
@@ -1,0 +1,20 @@
+{{ define "main" }}
+<!-- This is for the /news/index.html (content/news/_index.md) page -->
+<section class="front-section">
+    <div class="newsletter container golden-grid">
+        {{ with index .CurrentSection.RegularPages 0 }}
+        <div class="col-wide">
+            <h1>{{ .Title }}</h1>
+
+            <div style="margin-top: 0.5em; margin-bottom: 0.5em;">
+                <a class="release-date" href="{{ .RelPermalink }}">{{ .Date.Format "January 2006" }}</a>
+            </div>
+
+            {{ .Content }}
+        </div>
+        {{ end }}
+
+        {{ partial "news_sidebar.html" . }}
+    </div>
+</section>
+{{ end }}

--- a/layouts/news/single.html
+++ b/layouts/news/single.html
@@ -1,18 +1,18 @@
 {{ define "main" }}
-<section class="front-section">
-    <div class="newsletter container golden-grid">
-        <div class="col-wide">
-            {{ $latest := index (where .Site.RegularPages "Section" "posts") 0 }}
-            <h1>{{ $latest.Title }}</h1>
-
+<div class="newsletter container golden-grid">
+    <div class="col-wide">
+        <div class="post-header">
+            <h1>{{ .Title }}</h1>
             <div style="margin-top: 0.5em; margin-bottom: 0.5em;">
-                <a class="release-date" href="{{ $latest.RelPermalink }}">{{ $latest.Date.Format "January 2006" }}</a>
+                <em class="release-date">{{ .Date.Format "January 2006" }}</em>
             </div>
-
-            {{ $latest.Content }}
         </div>
 
-        {{ partial "news_sidebar.html" . }}
+        <div class="post-content">
+            {{ .Content }}
+        </div>
     </div>
-</section>
+
+    {{ partial "news_sidebar.html" . }}
+</div>
 {{ end }}

--- a/layouts/single.html
+++ b/layouts/single.html
@@ -1,22 +1,4 @@
 {{ define "main" }}
-{{ if eq .Section "posts" }}
-<div class="newsletter container golden-grid">
-    <div class="col-wide">
-        <div class="post-header">
-            <h1>{{ .Title }}</h1>
-            <div style="margin-top: 0.5em; margin-bottom: 0.5em;">
-                <em class="release-date">{{ .Date.Format "January 2006" }}</em>
-            </div>
-        </div>
-
-        <div class="post-content">
-            {{ .Content }}
-        </div>
-    </div>
-
-    {{ partial "news_sidebar.html" . }}
-</div>
-{{ else }}
 <!-- <div class="post-header"> -->
 <!--     <h1>{{ .Title }}</h1> -->
 <!--     <h2> -->
@@ -32,5 +14,4 @@
     {{ .Content }}
 
 </div>
-{{ end }}
 {{ end }}


### PR DESCRIPTION
Problem:
All news posts where defined in `content/posts` and then permalinked
to `/news`.

Solution:
Just define in `content/news`.

Some news items had `/news/2022/nov/` style permalinks. These are kept as aliases. 