### PR TITLE
Add navigation bar to docs

### DIFF
--- a/content/_misc/_index.md
+++ b/content/_misc/_index.md
@@ -1,0 +1,8 @@
+---
+cascade:
+- build:
+    list: local
+    publishResources: false
+    render: never
+title: Headless section
+---

--- a/content/_misc/whatisnvim.md
+++ b/content/_misc/whatisnvim.md
@@ -1,6 +1,5 @@
 ---
 title: whatisnvim
-headless: true
 ---
 
 ### What is Neovim?

--- a/layouts/_partials/footer.html
+++ b/layouts/_partials/footer.html
@@ -1,5 +1,19 @@
 <footer>
-  <div class="container flex">
+<div class="container flex">
+{{ if .InSection (site.GetPage "/doc/user") }}
+    <div class="generator-stats">
+      Generated at {{ now.Format "2006-01-02 15:04" }} from
+      <code><a href="https://github.com/neovim/neovim/commit/{{ .Params.commit }}">
+        {{ substr .Params.commit 0 7 }}
+      </a></code>
+    </div>
+    <div class="generator-stats">
+      parse_errors: {{ .Params.parseErrors }}
+      (<a href="{{ .Params.bugUrl }}" target="_blank">report docs bug...</a>)
+      | <span title="{{ .Params.noiseLines }}">noise_lines: {{ .Params.noiseLinesCount }}</span>
+    </div>
+    <div></div>
+{{ else }}
     <div>
       {{ range $index, $element := .Site.Menus.main }}
       <a href="{{ .URL }}">{{ .Name }}</a>
@@ -12,5 +26,6 @@
     <div>
       This site's source is <a href="https://github.com/neovim/neovim.github.io/">hosted on GitHub</a>.
     </div>
-  </div>
+{{ end }}
+</div>
 </footer>

--- a/layouts/baseof.html
+++ b/layouts/baseof.html
@@ -14,7 +14,13 @@
     <meta property="og:title" content="Neovim">
     <meta property="og:type" content="website">
 
-    <title>{{ if .Title }}{{ .Title }} - {{ end }}{{ .Site.Title }}</title>
+    <title>
+      {{- if .Title }}{{ .Title }} - {{ end -}}
+      {{ .Site.Title }}
+      {{ if .InSection (site.GetPage "/doc/user") }}
+      docs
+      {{- end -}}
+    </title>
 
     <!-- algolia docsearch https://docsearch.algolia.com/docs/docsearch-v3/ -->
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@docsearch/css@3" />
@@ -31,6 +37,13 @@
     {{ else }}
     <link rel="canonical" href="{{ .RelPermalink }}">
     <meta property="og:url" content="{{ .RelPermalink }}">
+    {{ end }}
+
+    {{ if .InSection (site.GetPage "/doc/user") }}
+    <link href="/css/help.css" rel="stylesheet">
+    <link href="/highlight/styles/neovim.min.css" rel="stylesheet">
+    <script src="/highlight/highlight.min.js"></script>
+    <script>hljs.highlightAll();</script>
     {{ end }}
     <link href="{{ .Site.BaseURL }}.{{ .Site.Params.news.feed }}" rel="alternate" title="{{ .Site.Params.news.name }}" type="application/rss+xml">
 </head>
@@ -53,7 +66,6 @@
         indexName: 'nvim',
       });
     </script>
-
 </body>
 
 </html>

--- a/layouts/doc/user/single.html
+++ b/layouts/doc/user/single.html
@@ -1,97 +1,39 @@
-<!DOCTYPE html>
-<html>
+{{ define "main" }}
+<div class="container golden-grid help-body">
+  <div class="col-wide">
+    <a name="{{ .Params.firstTag1 }}" href="#{{ .Params.firstTag2 }}">
+      <h1 id="{{ .Params.firstTag2 }}">{{ .Title }}</h1>
+    </a>
+    <p>
+      <i>
+        Nvim <code>:help</code> pages, <a
+          href="https://github.com/neovim/neovim/blob/master/src/gen/gen_help_html.lua">generated</a>
+        from <a href="https://github.com/neovim/neovim/blob/master/runtime/doc/{{ .Params.basename }}">source</a>
+        using the <a href="https://github.com/neovim/tree-sitter-vimdoc">tree-sitter-vimdoc</a> parser.
+      </i>
+    </p>
+    <hr />
+    {{ .Content }}
+  </div>
 
-<head>
-  <meta charset="utf-8">
-  <meta http-equiv="X-UA-Compatible" content="IE=edge">
-  <meta name="viewport" content="width=device-width, initial-scale=1">
-  <meta name="description" content="Neovim user documentation">
-
-  <!-- algolia docsearch https://docsearch.algolia.com/docs/docsearch-v3/ -->
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@docsearch/css@3" />
-  <link rel="preconnect" href="https://X185E15FPG-dsn.algolia.net" crossorigin />
-
-  <link href="/css/bootstrap.min.css" rel="stylesheet">
-  <link href="/css/main.css" rel="stylesheet">
-  <link href="/css/help.css" rel="stylesheet">
-  <link href="/highlight/styles/neovim.min.css" rel="stylesheet">
-
-  <script src="/highlight/highlight.min.js"></script>
-  <script>hljs.highlightAll();</script>
-  <title>{{ .Title }} - Neovim docs</title>
-</head>
-
-<body>
-  <header class="container">
-    <nav class="navbar navbar-expand-lg">
-      <div class="container-fluid">
-        <a href="/" class="navbar-brand" aria-label="logo">
-            {{ partial "logo.svg" . }}
-        </a>
-        <div id="docsearch"></div> <!-- algolia docsearch https://docsearch.algolia.com/docs/docsearch-v3/ -->
-      </div>
-    </nav>
-  </header>
-
-  <div class="container golden-grid help-body">
-    <div class="col-wide">
-      <a name="{{ .Params.firstTag1 }}" href="#{{ .Params.firstTag2 }}">
-        <h1 id="{{ .Params.firstTag2 }}">{{ .Title }}</h1>
-      </a>
-      <p>
-        <i>
-          Nvim <code>:help</code> pages, <a
-            href="https://github.com/neovim/neovim/blob/master/src/gen/gen_help_html.lua">generated</a>
-          from <a href="https://github.com/neovim/neovim/blob/master/runtime/doc/{{ .Params.basename }}">source</a>
-          using the <a href="https://github.com/neovim/tree-sitter-vimdoc">tree-sitter-vimdoc</a> parser.
-        </i>
-      </p>
-      <hr />
-      {{ .Content }}
-    </div>
-
-    <div class="col-narrow toc">
-      <div><a href="/doc/user/">Main</a></div>
-      <div><a href="/doc/user/vimindex/">Commands index</a></div>
-      <div><a href="/doc/user/quickref/">Quick reference</a></div>
-      <hr />
-      {{ $n := 0 }}
-      {{ range .Params.headings }}
-      {{ $n = add $n (add 1 (len .subheadings)) }}
-      {{ end }}
-      {{ range .Params.headings }}
-      <div class="help-toc-h1"><a href="#{{ .tag }}">{{ lower .name | title }}</a>
-        {{ if or (lt $n 30) (lt (len $.Params.headings) 10) }}
-        {{ range .subheadings }}
-        <div class="help-toc-h2"><a href="#{{ .tag }}">{{ lower .name | title }}</a></div>
-        {{- end }}
-        {{- end }}
-      </div>
+  <div class="col-narrow toc">
+    <div><a href="/doc/user/">Main</a></div>
+    <div><a href="/doc/user/vimindex/">Commands index</a></div>
+    <div><a href="/doc/user/quickref/">Quick reference</a></div>
+    <hr />
+    {{ $n := 0 }}
+    {{ range .Params.headings }}
+    {{ $n = add $n (add 1 (len .subheadings)) }}
+    {{ end }}
+    {{ range .Params.headings }}
+    <div class="help-toc-h1"><a href="#{{ .tag }}">{{ lower .name | title }}</a>
+      {{ if or (lt $n 30) (lt (len $.Params.headings) 10) }}
+      {{ range .subheadings }}
+      <div class="help-toc-h2"><a href="#{{ .tag }}">{{ lower .name | title }}</a></div>
+      {{- end }}
       {{- end }}
     </div>
+    {{- end }}
   </div>
-  <footer>
-    <div class="container flex">
-      <div class="generator-stats">
-        Generated at {{ now.Format "2006-01-02 15:04" }} from <code><a
-            href="https://github.com/neovim/neovim/commit/{{ .Params.commit }}">{{ substr .Params.commit 0 7 }}</a></code>
-      </div>
-      <div class="generator-stats">
-        parse_errors: {{ .Params.parseErrors }} (<a href="{{ .Params.bugUrl }}" target="_blank">report docs bug...</a>)
-        | <span title="{{ .Params.noiseLines }}">noise_lines: {{ .Params.noiseLinesCount }}</span>
-      </div>
-      <div>
-        <!-- algolia docsearch https://docsearch.algolia.com/docs/docsearch-v3/ -->
-        <script src="https://cdn.jsdelivr.net/npm/@docsearch/js@3"></script>
-        <script type="module">
-          docsearch({
-            container: '#docsearch',
-            appId: 'X185E15FPG',
-            apiKey: 'b5e6b2f9c636b2b471303205e59832ed',
-            indexName: 'nvim',
-          });
-        </script>
-  </footer>
-</body>
-
-</html>
+</div>
+{{ end }}


### PR DESCRIPTION
Adds the navigation bar to the docs by wrapping the docs-specific layout with the baseof.html template

| Before | After |
|--------|-------|
| <img width="1399" height="835" alt="image" src="https://github.com/user-attachments/assets/1b8d1ab5-0977-412c-9724-e8661df83744" /> | <img width="1398" height="835" alt="image" src="https://github.com/user-attachments/assets/77fc5b1c-f09f-4e42-a873-a34152811e36" /> |
