### PR TITLE
Highlight current page in navbar ("active" behavior)

### DIFF
--- a/content/_index.md
+++ b/content/_index.md
@@ -1,6 +1,5 @@
 ---
 title: Home
-active: Home
 redirect_from:
   - /development-wiki/
 params:

--- a/content/about.md
+++ b/content/about.md
@@ -1,6 +1,5 @@
 ---
 title: About
-active: About
 layout: mainpage
 ---
 

--- a/content/charter.md
+++ b/content/charter.md
@@ -1,6 +1,5 @@
 ---
 title: Vision
-active: About
 layout: mainpage
 ---
 

--- a/content/news/_index.md
+++ b/content/news/_index.md
@@ -1,4 +1,3 @@
 ---
 title: News
-active: News
 ---

--- a/content/news/archive.md
+++ b/content/news/archive.md
@@ -1,6 +1,5 @@
 ---
 title: News archive
-active: News
 layout: list
 url: /news/archive/
 ---

--- a/content/roadmap.md
+++ b/content/roadmap.md
@@ -1,6 +1,5 @@
 ---
 title: Roadmap
-active: About
 layout: mainpage
 ---
 

--- a/content/screenshots.md
+++ b/content/screenshots.md
@@ -1,6 +1,5 @@
 ---
 title: Screenshots
-active: Screenshots
 layout: mainpage
 ---
 

--- a/content/sponsors.html
+++ b/content/sponsors.html
@@ -1,6 +1,5 @@
 ---
 title: Sponsors
-active: Sponsors
 ---
 
 <div class="container golden-grid">

--- a/layouts/_partials/nav.html
+++ b/layouts/_partials/nav.html
@@ -1,7 +1,7 @@
 <header class="container">
   <nav class="navbar navbar-expand-lg">
     <div class="container-fluid">
-      <a href="/" class="navbar-brand" aria-label="logo">
+      <a href="/" class="navbar-brand" {{ if eq .RelPermalink "/" }}aria-current="page"{{ end }} aria-label="logo">
         {{ partial "logo.svg" . }}
       </a>
 
@@ -18,16 +18,28 @@
       <div class="collapse navbar-collapse justify-content-end" id="navbarNav">
         <ul class="navbar-nav">
           {{ range .Site.Menus.main }}
+          {{ $active := strings.Contains $.RelPermalink .URL }}
+
           {{ if .HasChildren }}
 
           <li class="nav-item dropdown">
-            <a class="nav-link dropdown-toggle" href="#" role="button" data-bs-toggle="dropdown" aria-expanded="false"
-              id="neovimDropdown">{{ .Name }}</a>
+            <a
+              class="nav-link dropdown-toggle {{ if $active }}active{{ end }}"
+              {{ if eq $.RelPermalink .URL }}aria-current="page"{{ end }}
+              href="#" role="button"
+              data-bs-toggle="dropdown"
+              aria-expanded="false"
+              id="neovimDropdown"
+            >{{ .Name }}</a>
             <ul class="dropdown-menu" aria-labelledby="neovimDropdown">
               {{ range .Children }}
 
               <li>
-                <a class="dropdown-item" href="{{ .URL }}">
+                <a
+                  class="dropdown-item {{ if eq $.RelPermalink .URL }}active{{ end }}"
+                  {{ if eq $.RelPermalink .URL }}aria-current="page"{{ end }}
+                  href="{{ .URL }}"
+                >
                   {{ .Name }}
                 </a>
               </li>
@@ -37,7 +49,11 @@
           </li>
           {{ else }}
           <li class="nav-item">
-            <a href="{{ .URL }}" class="nav-link">{{ .Name }}</a>
+            <a
+              href="{{ .URL }}"
+              class="nav-link {{ if $active }}active{{ end }}"
+              {{ if eq $.RelPermalink .URL }}aria-current="page"{{ end }}
+            >{{ .Name }}</a>
           </li>
 
           {{ end }} {{ end }}

--- a/static/css/main.css
+++ b/static/css/main.css
@@ -237,6 +237,12 @@ samp {
   color: var(--accent-color);
 }
 
+/* Highlight the currently active menu item */
+.nav-link.active,
+.nav-item.dropdown:has(.dropdown-menu a.active) > .nav-link {
+  color: var(--accent-color) !important;
+}
+
 .navbar-toggler {
   border-width: 0;
   color: var(--fg-color);


### PR DESCRIPTION
Problem:
We used to highlight the currently active navbar item but its behavior
got lost in the Hugo conversion.

Solution:
Bring it back. Set aria-current="page" and "active" class to navbar
items where the current URL is relative too. E.g. URL in nav: `/doc/`
and current page: `/doc/install/` would highlight that nav item.

For dropdown items this also works if one of the sub items in the
dropdown is active.


| Before | After |
|--------|--------|
| <img width="481" height="231" alt="image" src="https://github.com/user-attachments/assets/ca19e923-79a9-4bb5-89bd-81fa615c9c58" /> | <img width="508" height="236" alt="image" src="https://github.com/user-attachments/assets/70f56fdd-c79d-4b42-8ac8-9d0dbc4aab07" /> |
| <img width="718" height="152" alt="image" src="https://github.com/user-attachments/assets/e9eb08dc-5e05-43c3-88ce-603587dde182" /> | <img width="714" height="170" alt="image" src="https://github.com/user-attachments/assets/07c09bd6-4c92-4f6c-8529-ca2a2396c030" /> |