### PR TITLE
Include the tag with a redirect from .html pages

### DIFF
--- a/.github/actions/build-site/action.yaml
+++ b/.github/actions/build-site/action.yaml
@@ -17,7 +17,7 @@ runs:
     - name: Install Hugo CLI
       shell: bash
       env:
-        HUGO_VERSION: "0.152.2"
+        HUGO_VERSION: "0.156.0"
       run: |
         wget -O ${{ runner.temp }}/hugo.deb \
           https://github.com/gohugoio/hugo/releases/download/v${HUGO_VERSION}/hugo_extended_${HUGO_VERSION}_linux-amd64.deb \

--- a/layouts/alias.html
+++ b/layouts/alias.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html lang="{{ site.Language.LanguageCode }}">
+
+<head>
+  <title>{{ .Permalink }}</title>
+  {{ with .OutputFormats.Canonical }}<link rel="{{ .Rel }}" href="{{ .Permalink }}">{{ end }}
+  <meta charset="utf-8">
+  <script defer>
+    const target = "{{ .Permalink }}"
+    const query = window.location.search
+    const hash = window.location.hash
+    window.location.replace(target + query + hash)
+  </script>
+  <!-- non-JS fallback, doesn't include the hash/anchor -->
+  <meta http-equiv="refresh" content="0; url={{ .Permalink }}">
+</head>
+
+</html>


### PR DESCRIPTION
Problem:
Old url `/doc/user/api.html#api` would redirect to `/doc/user/api/`,
missing the `#api` tag.

Solution:
JS is needed to append the anchor tag to the new URL. Bonus points:
`window.location.replace()` replaces it in history, meaning the back
button won't go to the .html url. The previous `<meta http-equiv="...">`
method is still included as non-JS fallback.
