### PR TITLE
fix(doc): redirect to absolute doc path

### DIFF
--- a/layouts/doc/user/helptag.html
+++ b/layouts/doc/user/helptag.html
@@ -27,7 +27,7 @@ querystring parameter. The page gets tags from the "/doc/user/helptags.json" fil
           throw new Error('helptag not found: "' + tag + '"')
         }
 
-        window.location.href = tagmap[tag]
+        window.location.replace(`/doc/user/${tagmap[tag]}`)
       } catch (err) {
         console.error(err)
         if (errorDiv) {


### PR DESCRIPTION
Problem:
Because of moving `/doc/user/helppage.html` pages to `/doc/user/helppage/` to helptag.html redirect doesn't work. The links in the tagmap (helptags.json) are relative, e.g. `pack/#vim.pack`, which redirects to `/doc/user/helptag/pack/#vim.pack` instead of `/doc/user/pack/#vim.pack`.

Solution:
Use an absolute URL.

Bonus:
`window.location.replace()` removes the `/helptag/` visit from browser history.
