### PR TITLE
fix(ci): don't minify html to preserve tabs in old-style docs tables

### DIFF
--- a/.github/actions/build-site/action.yaml
+++ b/.github/actions/build-site/action.yaml
@@ -33,5 +33,5 @@ runs:
         HUGO_ENVIRONMENT: production
         HUGO_ENV: production
       run: |
-        hugo --gc --minify --baseURL "$BASE_URL"
+        hugo --gc --baseURL "$BASE_URL"
 


### PR DESCRIPTION
## Problem

Hugo's `--minify` flag minifies HTML and thereby reduces all consecutive whitespace to a single space character (instead of tab), not rendering the "old-style" tab-delimited tables in the docs. This is probably a bug on Hugo's side (and possibly introduced somewhere introduced between v0.152.2 and v0.156.0, 8a75395).

## Solution

Disable minification of the HTML for now.

Closes: #451
