### PR TITLE
fix(layout): improve meta tags in <head>

### DIFF
--- a/content/_index.md
+++ b/content/_index.md
@@ -1,5 +1,5 @@
 ---
-title: Home
+title: ""
 redirect_from:
   - /development-wiki/
 params:

--- a/hugo.toml
+++ b/hugo.toml
@@ -1,6 +1,9 @@
 baseURL = 'https://neovim.io/'
-languageCode = 'en-us'
+languageCode = 'en-US'
 title = 'Neovim'
+
+# needed for og:description to be the website description (below in [params])
+summaryLength = 0
 
 [frontmatter]
   date = [":filename", ":default"]
@@ -16,7 +19,10 @@ title = 'Neovim'
   path = "/"
 
 [params]
-  description = "vim out of the box"
+  description = "hyperextensible Vim-based text editor"
+
+  # Used for social previews
+  images = ['/logos/neovim-logo-social-preview.png']
 
   [params.news]
     name = "Neovim Newsletter"

--- a/layouts/baseof.html
+++ b/layouts/baseof.html
@@ -3,20 +3,16 @@
 
 <head>
     <meta charset="utf-8">
-    <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <meta name="description" content="{{ .Site.Params.description }}">
-    <meta property="og:description" content="Hyperextensible Vim-based text editor">
-    <meta property="og:image"
-        content="https://raw.githubusercontent.com/neovim/neovim.github.io/master/logos/neovim-logo-social-preview.png">
-    <meta property="og:image:alt" content="Robot Marvim pointing at Neovim logo">
-    <meta property="og:site_name" content="Neovim">
-    <meta property="og:title" content="Neovim">
-    <meta property="og:type" content="website">
+    <meta name="description" content="{{ site.Params.description }}">
+
+    {{ partial "opengraph.html" . }}
+    {{ partial "twitter_cards.html" . }}
+    {{ partial "schema.html" . }}
 
     <title>
       {{- if .Title }}{{ .Title }} - {{ end -}}
-      {{ .Site.Title }}
+      {{ .Site.Title -}}
       {{ if .InSection (site.GetPage "/doc/user") }}
       docs
       {{- end -}}
@@ -35,8 +31,7 @@
     {{ if eq .RelPermalink "/404.html" }}
     <meta name="robots" content="noindex">
     {{ else }}
-    <link rel="canonical" href="{{ .RelPermalink }}">
-    <meta property="og:url" content="{{ .RelPermalink }}">
+    <link href="{{ .Permalink }}" rel="canonical">
     {{ end }}
 
     {{ if .InSection (site.GetPage "/doc/user") }}
@@ -45,7 +40,7 @@
     <script src="/highlight/highlight.min.js"></script>
     <script>hljs.highlightAll();</script>
     {{ end }}
-    <link href="{{ .Site.BaseURL }}.{{ .Site.Params.news.feed }}" rel="alternate" title="{{ .Site.Params.news.name }}" type="application/rss+xml">
+    <link href="{{ absURL .Site.Params.news.feed }}" rel="alternate" title="{{ .Site.Params.news.name }}" type="application/rss+xml">
 </head>
 
 <body>

--- a/layouts/home.html
+++ b/layouts/home.html
@@ -1,6 +1,6 @@
 {{ define "main" }}
 <section class="masthead">
-    <h1 class="lead">hyperextensible Vim-based text editor</h1>
+    <h1 class="lead">{{ site.Params.description }}</h1>
     <p>
         <a href="/doc/install/" class="btn">Install Now</a>
         <a href="https://dotfyle.com/plugins" class="btn">Get Plugins</a>


### PR DESCRIPTION
Using Hugo's built-in templates for opengraph, Twitter Cards and Schema meta tags.

Most notable changes:
- Title for the homepage is now `Neovim` instead of `Home - Neovim`
- Socials image url is from neovim.io instead of Github repo
- Adds Twitter Cards and Schema

Old:

```html
<head>
	<meta name="generator" content="Hugo 0.156.0">
    <meta charset="utf-8">
    <meta http-equiv="X-UA-Compatible" content="IE=edge">
    <meta name="viewport" content="width=device-width, initial-scale=1">
    <meta name="description" content="vim out of the box">
    <meta property="og:description" content="Hyperextensible Vim-based text editor">
    <meta property="og:image" content="https://raw.githubusercontent.com/neovim/neovim.github.io/master/logos/neovim-logo-social-preview.png">
    <meta property="og:image:alt" content="Robot Marvim pointing at Neovim logo">
    <meta property="og:site_name" content="Neovim">
    <meta property="og:title" content="Neovim">
    <meta property="og:type" content="website">
    <title>Home - Neovim
      </title>
    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@docsearch/css@3">
    <link rel="preconnect" href="https://X185E15FPG-dsn.algolia.net" crossorigin="">
    <link href="/css/bootstrap.min.css" rel="stylesheet">
    <link href="/css/main.css" rel="stylesheet">
    <link href="/css/neovim-hi.css" rel="stylesheet">
    <link rel="canonical" href="/">
    <meta property="og:url" content="/">
    <link href="/./news.xml" rel="alternate" title="Neovim Newsletter" type="application/rss+xml">
</head>
```

New:

```html
<head>
	<meta name="generator" content="Hugo 0.156.0">
    <meta charset="utf-8">
    <meta name="viewport" content="width=device-width, initial-scale=1">
    <meta name="description" content="hyperextensible Vim-based text editor">
    <meta property="og:url" content="https://neovim.io/">
  <meta property="og:site_name" content="Neovim">
  <meta property="og:title" content="Neovim">
  <meta property="og:description" content="hyperextensible Vim-based text editor">
  <meta property="og:locale" content="en_US">
  <meta property="og:type" content="website">
    <meta property="og:image" content="https://neovim.io/logos/neovim-logo-social-preview.png">
  <meta name="twitter:card" content="summary_large_image">
  <meta name="twitter:image" content="https://neovim.io/logos/neovim-logo-social-preview.png">
  <meta name="twitter:title" content="Neovim">
  <meta name="twitter:description" content="hyperextensible Vim-based text editor">
  <meta itemprop="name" content="Neovim">
  <meta itemprop="description" content="hyperextensible Vim-based text editor">
  <meta itemprop="datePublished" content="2026-02-21T00:00:00+00:00">
  <meta itemprop="dateModified" content="2026-02-21T00:00:00+00:00">
  <meta itemprop="wordCount" content="176">
  <meta itemprop="image" content="https://neovim.io/logos/neovim-logo-social-preview.png">
    <title>Neovim</title>
    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@docsearch/css@3" />
    <link rel="preconnect" href="https://X185E15FPG-dsn.algolia.net" crossorigin />
    <link href="/css/bootstrap.min.css" rel="stylesheet">
    <link href="/css/main.css" rel="stylesheet">
    <link href="/css/neovim-hi.css" rel="stylesheet">
    <link href="https://neovim.io/" rel="canonical">
    <link href="https://neovim.io/news.xml" rel="alternate" title="Neovim Newsletter" type="application/rss+xml">
</head>
```

(Note: I removed empty lines for this comparison)