### PR TITLE
refactor: add scratch shortcode for Markdown-based page sections

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,28 +30,49 @@ just do the following:
 
 ## Maintenance
 
-Notes:
+#### Creating content / blog posts
 
-- Create new blog posts (news items) using the command:
-  ```bash
-  hugo new content content/news/<filename>.md
-  ```
-  The filename won't show up on the site -- the page url will be in the form of
-  `/news/2026/12/` where 2026 is the year and 12 the month, as defined in the
-  front matter.
-- Site search (for `:help` docs) is served by [Algolia Docsearch](https://docsearch.algolia.com/).
-    - The javascript and UI container were setup in [this commit](https://github.com/neovim/neovim.github.io/commit/ce9aef12eb1c98135965e3a9c5c792bf9e506a76).
-    - The docs pages don't use the layout so they also need to [manually include](https://github.com/neovim/neovim/pull/23839) the javascript and define a UI container.
-    - Admin: https://www.algolia.com/apps/X185E15FPG/dashboard
-    - Config: [algolia-docsearch-config.js](./algolia-docsearch-config.js)
-- Codeblock highlighting
-    - The highlighting for the generated help docs (`/doc/user/`) is done by:
-        - `static/css/neovim-hi.css`
-        - `static/highlight/styles/neovim.min.css`
-    - Hugo can provide highlighting for markdown codeblocks, see the `[markup]` section in `hugo.toml`.
-        - To list/generate Hugo syntax themes:
-          ```
-          hugo gen chromastyles --style nord > static/css/syntax.css
-          ```
-        - To use the them, commit `static/css/syntax.css` and enable it by uncommenting this line: https://github.com/neovim/neovim.github.io/blob/eb266d7929eff8693cc05ca96732a2daf431e834/layouts/_default/baseof.html#L27
-          - And fiddle with the `[markup]` section in `hugo.toml`.
+Create new blog posts (news items) using the command:
+
+```bash
+hugo new content content/news/<filename>.md
+```
+
+The filename won't show up on the site -- the page url will be in the form of
+`/news/2026/12/` where 2026 is the year and 12 the month, as defined in
+hugo.toml.
+
+To include (Markdown) content separate from the main content, use the
+[scratch](scratch) [shortcode](shortcodes) and add
+`{{ .Page.Scratch.Get "<name>" }}` in the layout of that page. See #457 for an
+example.
+
+#### Site search
+
+Site search (for `:help` docs) is served by [Algolia Docsearch](https://docsearch.algolia.com/).
+
+- The javascript and UI container were setup in [this commit](https://github.com/neovim/neovim.github.io/commit/ce9aef12eb1c98135965e3a9c5c792bf9e506a76).
+- The docs pages don't use the layout so they also need to [manually include](https://github.com/neovim/neovim/pull/23839) the javascript and define a UI container.
+- Admin: https://www.algolia.com/apps/X185E15FPG/dashboard
+- Config: [algolia-docsearch-config.js](./algolia-docsearch-config.js)
+
+### Codeblock highlighting
+
+See [neovim-hi.css](./static/css/neovim-hi.css) and
+[neovim.min.css](./static/highlight/styles/neovim.min.css) for the highlighting
+of code examples in generated help docs (`/doc/user/`).
+
+Hugo can provide highlighting for markdown codeblocks, see the `[markup]`
+section in `hugo.toml`. To list/generate Hugo syntax themes:
+
+```bash
+hugo gen chromastyles --style nord > static/css/syntax.css
+```
+
+To use the them, commit `static/css/syntax.css` and enable it by uncommenting
+this line:
+https://github.com/neovim/neovim.github.io/blob/eb266d7929eff8693cc05ca96732a2daf431e834/layouts/_default/baseof.html#L27
+and fiddle with the `[markup]` section in `hugo.toml`.
+
+[scratch]: ./layouts/_shortcodes/scratch.html
+[shortcodes]: https://gohugo.io/content-management/shortcodes/

--- a/content/_index.md
+++ b/content/_index.md
@@ -2,36 +2,6 @@
 title: ""
 redirect_from:
   - /development-wiki/
-params:
-  impressions:
-    - quote: Neovim is exactly what it claims to be. It fixes every issue I have with Vim.
-      name: Geoff Greer
-      link: http://geoff.greer.fm/2015/01/15/why-neovim-is-better-than-vim/
-    - quote: Full-screen Neovim looks cool as hell!
-      name: DHH
-      link: https://x.com/dhh/status/1764465909316583659
-    - quote: A nice looking website, that’s one thing Neovim did right.
-      name: Bram Moolenaar
-      link: https://www.binpress.com/vim-creator-bram-moolenaar-interview/
-  faq:
-    - question: What is the project status?
-      answer: |
-        The current [stable release](https://github.com/neovim/neovim/releases/latest)
-        version is `0.11` ([RSS](https://github.com/neovim/neovim/tags.atom)).
-        See the [roadmap](/roadmap/) for progress and plans.
-    - question: Is Neovim trying to turn Vim into an IDE?
-      answer: |
-        With 30% less source-code than Vim, the [vision](/charter/)
-        of Neovim is to enable new applications without compromising Vim's
-        traditional roles.
-    - question: Will Neovim deprecate Vimscript?
-      answer: |
-        No. Lua is built-in, but Vimscript is supported with the
-        [world's most advanced Vimscript engine](/doc/user/api/#nvim_parse_expression()).
-    - question: Which plugins does Neovim support?
-      answer: |
-        Vim 8.x plugins and
-        [much more](https://github.com/neovim/neovim/wiki/Related-projects).
 ---
 
 ## Features
@@ -73,3 +43,76 @@ params:
 - Fully compatible with Vim's editing model and Vimscript v1.
 - Start with [`:help nvim-from-vim`](/doc/user/nvim/#nvim-from-vim)
   if you already use Vim. If not, try `:Tutor`.
+
+
+{{% scratch "chat" %}}
+## Chat
+
+- [Follow \@Neovim on X](https://x.com/Neovim),
+  [Mastodon](https://hachyderm.io/@neovim),
+  [Bluesky](https://bsky.app/profile/neovim.io)
+- Discuss the project in [GitHub
+  Discussions](https://github.com/neovim/neovim/discussions), or chat in
+  [#neovim:matrix.org](https://matrix.to/#/#neovim:matrix.org) or
+  #neovim on `irc.libera.chat`.
+- Contribute code, report bugs and request features at
+  [GitHub](https://github.com/neovim/neovim).
+- Ask usage and configuration questions at [GitHub
+  Discussions](https://github.com/neovim/neovim/discussions) or
+  [vi.stackexchange.com](https://vi.stackexchange.com).
+{{% /scratch %}}
+
+{{% scratch "GUIs" %}}
+## GUIs
+
+Neovim UIs are "inverted plugins". Here are some popular ones:
+- [Firenvim](https://github.com/glacambre/firenvim) (Nvim in your web
+  browser!)
+- [vscode-neovim](https://github.com/vscode-neovim/vscode-neovim) (Nvim
+  in VSCode!)
+- [Neovide](https://neovide.dev/)
+- [Goneovim](https://github.com/akiyosi/goneovim)
+- [GNvim (GTK4)](https://github.com/vhakulinen/gnvim)
+- [FVim](https://github.com/yatli/fvim)
+- [Nvy](https://github.com/RMichelsen/Nvy)
+- [Neovim Qt (Qt5)](https://github.com/equalsraf/neovim-qt)
+- [VimR (macOS)](https://github.com/qvacua/vimr)
+- [More...](https://github.com/neovim/neovim/wiki/Related-projects#gui)
+{{% /scratch %}}
+
+
+{{% scratch "impressions" %}}
+## Impressions
+
+"Neovim is exactly what it claims to be. It fixes every issue I have
+with Vim."
+[---Geoff Greer](http://geoff.greer.fm/2015/01/15/why-neovim-is-better-than-vim/)
+
+"Full-screen Neovim looks cool as hell!"
+[---DHH](https://x.com/dhh/status/1764465909316583659)
+
+"A nice looking website, that's one thing Neovim did right."
+[---Bram Moolenaar](https://www.binpress.com/vim-creator-bram-moolenaar-interview/)
+{{% /scratch %}}
+
+
+{{% scratch "faq" %}}
+## FAQ {#faqs}
+
+**What is the project status?**\
+The current [stable release](https://github.com/neovim/neovim/releases/latest)
+version is `0.11` ([RSS](https://github.com/neovim/neovim/tags.atom)). See the
+[roadmap](/roadmap/) for progress and plans.
+
+**Is Neovim trying to turn Vim into an IDE?**\
+With 30% less source-code than Vim, the [vision](/charter/) of Neovim is to
+enable new applications without compromising Vim's traditional roles.
+
+**Will Neovim deprecate Vimscript?**\
+No. Lua is built-in, but Vimscript is supported with the [world's most advanced
+Vimscript engine](/doc/user/api/#nvim_parse_expression()).
+
+**Which plugins does Neovim support?**\
+Vim 8.x plugins and [much
+more](https://github.com/neovim/neovim/wiki/Related-projects).
+{{% /scratch %}}

--- a/content/doc/_index.md
+++ b/content/doc/_index.md
@@ -20,7 +20,7 @@ active: Documentation
 - Check the [FAQ](/doc/user/faq/#faq) and [breaking
   changes](/doc/user/news/#news-breaking) for common issues.
 
-{{% aside %}}
+{{% scratch "aside" %}}
 
 ## Developer
 
@@ -44,4 +44,4 @@ active: Documentation
 - [More clients
   (third-party)](https://github.com/neovim/neovim/wiki/Related-projects#api-clients)
 
-{{% /aside %}}
+{{% /scratch %}}

--- a/layouts/_shortcodes/aside.html
+++ b/layouts/_shortcodes/aside.html
@@ -1,1 +1,0 @@
-{{ .Page.Scratch.Set "aside" (.Inner | markdownify) }}

--- a/layouts/_shortcodes/scratch.html
+++ b/layouts/_shortcodes/scratch.html
@@ -1,0 +1,1 @@
+{{ .Page.Scratch.Set (.Get 0) (.Inner | markdownify) }}

--- a/layouts/home.html
+++ b/layouts/home.html
@@ -65,10 +65,7 @@
                 </dl> */}}
                 <p><a href="/news/archive/">More…</a></p>
 
-                <h2>Impressions</h2>
-                {{ range .Params.impressions }}
-                <p>"{{ .quote | markdownify }}" <a href="{{ .link }}">—{{ .name }}</a></p>
-                {{ end }}
+                {{ .Page.Scratch.Get "impressions" }}
             </div>
         </div>
     </div>
@@ -87,23 +84,7 @@
         </div>
 
         <div>
-            <h2 id="chat">Chat</h2>
-            <ul>
-              <li><a href="https://x.com/Neovim" class="twitter-follow-button">Follow &#64;Neovim on X</a>,
-                <a rel="me" href="https://hachyderm.io/@neovim">Mastodon</a>,
-                <a href="https://bsky.app/profile/neovim.io">Bluesky</a>
-              </li>
-              <li>Discuss the project in <a href="https://github.com/neovim/neovim/discussions">GitHub Discussions</a>, or
-                chat in <a href="https://matrix.to/#/#neovim:matrix.org">#neovim:matrix.org</a>
-                or #neovim on <code>irc.libera.chat</code>.
-              </li>
-              <li>Contribute code, report bugs and request features at <a
-                      href="https://github.com/neovim/neovim">GitHub</a>.</li>
-              <li>Ask usage and configuration questions at <a
-                      href="https://github.com/neovim/neovim/discussions">GitHub Discussions</a>
-                  or <a href="https://vi.stackexchange.com">vi.stackexchange.com</a>.
-              </li>
-            </ul>
+          {{ .Page.Scratch.Get "chat" }}
         </div>
 
     </div>
@@ -112,29 +93,10 @@
 <section class="front-section">
     <div class="container golden-grid">
         <div>
-            <h2 id="faqs">FAQ</h2>
-            <dl class="faqs">
-                {{ range .Params.faq }}
-                <dt>{{ .question | markdownify }}</dt>
-                <dd>{{ .answer | markdownify }}</dd>
-                {{ end }}
-            </dl>
+          {{ .Page.Scratch.Get "faq" }}
         </div>
         <div>
-            <h2>GUIs</h2>
-            Neovim UIs are "inverted plugins". Here are some popular ones:
-            <ul>
-                <li><a href="https://github.com/glacambre/firenvim">Firenvim</a> (Nvim in your web browser!)</li>
-                <li><a href="https://github.com/vscode-neovim/vscode-neovim">vscode-neovim</a> (Nvim in VSCode!)</li>
-                <li><a href="https://neovide.dev/">Neovide</a></li>
-                <li><a href="https://github.com/akiyosi/goneovim">Goneovim</a></li>
-                <li><a href="https://github.com/vhakulinen/gnvim">GNvim (GTK4)</a></li>
-                <li><a href="https://github.com/yatli/fvim">FVim</a></li>
-                <li><a href="https://github.com/RMichelsen/Nvy">Nvy</a></li>
-                <li><a href="https://github.com/equalsraf/neovim-qt">Neovim Qt (Qt5)</a></li>
-                <li><a href="https://github.com/qvacua/vimr">VimR (macOS)</a></li>
-                <li><a href="https://github.com/neovim/neovim/wiki/Related-projects#gui">More...</a></li>
-            </ul>
+          {{ .Page.Scratch.Get "GUIs" }}
         </div>
     </div>
 </section>

--- a/static/css/main.css
+++ b/static/css/main.css
@@ -65,7 +65,9 @@ a {
   transition: all ease-in-out 140ms;
 }
 
-a[href^="http"]:not([href*="neovim.io"]):not(.btn)::after {
+/* Add an "external link" icon next to anchors
+ * (but not when they're buttons or wrap images) */
+a[href^="http"]:not([href*="neovim.io"]):not(.btn):not(:has(img))::after {
   content: '';
   display: inline-block;
   width: 0.75em;


### PR DESCRIPTION
Problem:
Hugo only supports Markdown for a page's main content. Secondary sections (e.g. asides) must be written in raw HTML, making them harder to maintain.

Solution:
Add a "scratch" shortcode that stores its Markdown content in a named scratch variable. Layouts can then retrieve and render it by name.

---

**Note**: I've not included the sponsors section in this PR because it might be a better approach to combine this with the https://neovim.io/sponsors/ page (which shows different sponsors currently?

---

Only minor visual difference (LMK if it's a problem):

| Old | New |
|--------|--------|
| <img width="1295" height="538" alt="image" src="https://github.com/user-attachments/assets/d041de4a-ae62-430a-abeb-b5fb861c8637" /> | <img width="1248" height="460" alt="image" src="https://github.com/user-attachments/assets/5a15ce96-1a26-4487-9dd3-8f2e05995649" /> | 

---

**Note**: Also added a small fix commit to not add the external link icon to images.