### PR TITLE
ci: don't set baseURL from environment variable

### DIFF
--- a/.github/actions/build-site/action.yaml
+++ b/.github/actions/build-site/action.yaml
@@ -33,5 +33,5 @@ runs:
         HUGO_ENVIRONMENT: production
         HUGO_ENV: production
       run: |
-        hugo --gc --baseURL "$BASE_URL"
+        hugo --gc
 


### PR DESCRIPTION
Problem:
If baseURL is empty all URLs do not contain a basename. This works fine in most cases, but doesn't work for meta tags like `og:image` and the like[^1].

Solution:
Just use the baseURL set in hugo.toml in CI.

[^1]: See https://opengraph.dev/panel?url=http%3A%2F%2Fneovim.io. The logo is not shown.
