### PR TITLE
fix(layout): images and video should fit container

### DIFF
--- a/static/css/main.css
+++ b/static/css/main.css
@@ -238,6 +238,12 @@ samp {
   max-width: 90vw;
 }
 
+
+.col-wide img,
+.col-wide video {
+  max-width: 100%;
+}
+
 /*
  * Navbar
  *


### PR DESCRIPTION
Problem:
Images and videos had a larger width than their container on mobile devices, causing horizontal overflow.

Solution:
Set their max width to fit the container.

Reference: https://github.com/neovim/neovim.github.io/pull/469#issuecomment-4387347332
