### PR TITLE
feat(gendoc): Specify output format for gen_help_html.lua

### DIFF
--- a/gendoc.lua
+++ b/gendoc.lua
@@ -82,8 +82,8 @@ local function main()
   vim.cmd(('helptags ++t %s'):format(docdir))
   -- Generate html pages from the Vimdoc files
   local genhelp = dofile(joinpath(nvim_repo, 'src/gen/gen_help_html.lua'))
-  local res = genhelp.gen(docdir, usercontent, nil, commit_hash(srcdir))
-  --                                           ^ { 'lua.txt', 'starting.txt', }
+  local res = genhelp.gen(docdir, usercontent, 'html', nil, commit_hash(srcdir))
+  --                                                   ^ { 'lua.txt', 'starting.txt', }
 
   if res.err_count > 0 or #res.invalid_links > 0 then
     error(('Error generating pages: err_count: %d, #invalid_links: %d'):format(

--- a/gendoc.lua
+++ b/gendoc.lua
@@ -82,7 +82,7 @@ local function main()
   vim.cmd(('helptags ++t %s'):format(docdir))
   -- Generate html pages from the Vimdoc files
   local genhelp = dofile(joinpath(nvim_repo, 'src/gen/gen_help_html.lua'))
-  local res = genhelp.gen(docdir, usercontent, 'html', nil, commit_hash(srcdir))
+  local res = genhelp.gen('html', docdir, usercontent, nil, commit_hash(srcdir))
   --                                                   ^ { 'lua.txt', 'starting.txt', }
 
   if res.err_count > 0 or #res.invalid_links > 0 then


### PR DESCRIPTION
Relates to neovim/neovim#39950

https://github.com/neovim/neovim/pull/39946 adds an `output_format` to `gen_help_html.lua`, so the current patch needs to get merged immediately after that one.