### PR TITLE
config: "access denied: 'text/html' is not whitelisted"

### DIFF
--- a/hugo.toml
+++ b/hugo.toml
@@ -9,7 +9,7 @@ summaryLength = 0
   date = [":filename", ":default"]
 
 [security]
-  allowContent = ['.']
+  allowContent = ['.*']
 
 [permalinks]
   news = "/:section/:year/:month/"

--- a/hugo.toml
+++ b/hugo.toml
@@ -8,6 +8,9 @@ summaryLength = 0
 [frontmatter]
   date = [":filename", ":default"]
 
+[security]
+  allowContent = ['.']
+
 [permalinks]
   news = "/:section/:year/:month/"
 


### PR DESCRIPTION
Problem:

    $ hugo server --buildDrafts

    ERROR error building site: assemble: failed to create page from
    pageMetaSource /sponsors: "…/content/sponsors.html:1:1":
    access denied: "text/html" is not whitelisted in policy
    "security.allowContent"; the current security configuration is:

Solution:
idk

cc @yochem does this look like the right fix? I wonder why CI doesn't fail?