### PR TITLE
help: hide navbar and TOC when printing #341

### DIFF
--- a/static/css/help.css
+++ b/static/css/help.css
@@ -233,3 +233,18 @@ pre:hover {
   color: gray;
   font-size: smaller;
 }
+
+@media print {
+  /* The TOC is `position: fixed` (see above), so when printing it repeats over
+     the help text on every page and covers it. Hide the nav chrome on paper.
+     https://github.com/neovim/neovim.github.io/issues/341 */
+  .navbar,
+  .toc {
+    display: none;
+  }
+
+  /* With the TOC hidden, let the help text use the full page width. */
+  .golden-grid {
+    display: block;
+  }
+}


### PR DESCRIPTION
Fixes #341.

The docs TOC (`.col-narrow.toc`) is `position: fixed`, so when a `:help` page is printed it repeats over the help text on every page and the body is squeezed into the left ~65% column. This adds an `@media print` block to `help.css` (loaded only on `/doc/user` pages) that:

- hides the nav bar and the TOC when printing, and
- resets `.golden-grid` to a single column so the help text uses the full page width.

No effect on the on-screen layout.

### Visual diff (browser Print Preview of `/doc/user/`, same page both sides)

| Before — TOC overlaps text on every page | After — nav/TOC hidden, full-width |
|---|---|
| <img src="https://raw.githubusercontent.com/KangaZero/neovim.github.io/pr-493-assets/assets/real-before-page1.png" width="100%"> | <img src="https://raw.githubusercontent.com/KangaZero/neovim.github.io/pr-493-assets/assets/real-after-page1.png" width="100%"> |
| <img src="https://raw.githubusercontent.com/KangaZero/neovim.github.io/pr-493-assets/assets/real-before-page2.png" width="100%"> | <img src="https://raw.githubusercontent.com/KangaZero/neovim.github.io/pr-493-assets/assets/real-after-page2.png" width="100%"> |

Note how the fixed TOC prints on top of the body text on page 2 (before). The overlap also inflates the print length.