### PR TITLE
layout: improve masthead and navbar responsiveness on small screens

### DIFF
--- a/layouts/home.html
+++ b/layouts/home.html
@@ -1,7 +1,7 @@
 {{ define "main" }}
 <section class="masthead">
     <h1 class="lead">{{ site.Params.description }}</h1>
-    <p>
+    <p class="lead-buttons-container">
         <a href="/doc/install/" class="btn">Install Now</a>
         <a href="https://neovimcraft.com/" class="btn">Get Plugins</a>
     </p>

--- a/static/css/main.css
+++ b/static/css/main.css
@@ -270,6 +270,24 @@ samp {
   color: var(--fg-color);
 }
 
+@media (max-width: 991.98px) {
+  .navbar-toggler {
+    order: 3;
+  }
+
+  #docsearch {
+    margin-left: auto;
+    margin-right: 1em;
+    order: 2;
+  }
+
+  /* The expanded menu is flex-basis:100%; ordering it last makes it wrap
+     below the top row so docsearch + toggler stay put when it opens. */
+  .navbar-collapse {
+    order: 4;
+  }
+}
+
 /**
  * Logo
  */
@@ -323,6 +341,19 @@ samp {
   font-family: var(--sans-serif-fonts);
   margin: 0;
   padding-bottom: 0.25em;
+}
+
+@media (max-width: 525px) {
+  .lead-buttons-container {
+    margin: 0 3em;
+    display: flex;
+    flex-direction: column;
+  }
+
+  .lead-buttons-container .btn {
+    margin: 0.3em 0;
+    text-align: center;
+  }
 }
 
 /*


### PR DESCRIPTION
Two small-screen (mobile) improvements to the page header. **No change to the desktop (≥ `lg`) layout.**

### 1. Navbar — keep the toggler + search pinned right (below `lg`)

Previously the hamburger toggler sat **centred** when the menu was closed and then jumped to the **right** when opened. Now the search box and toggler are both pinned to the right in **both** states, so the toggler doesn't move when you open the menu.

| Before (closed, ~990px) | After (closed, ~990px) |
|---|---|
| <img src="https://raw.githubusercontent.com/KangaZero/neovim.github.io/responsive-assets/assets/responsive/before-990.png" width="100%"> | <img src="https://raw.githubusercontent.com/KangaZero/neovim.github.io/responsive-assets/assets/responsive/after-990.png" width="100%"> |

The collapsible menu is `flex-basis: 100%`, so it's ordered last and expands **below** the top row — the **search box no longer drops down** with the menu; it stays next to the toggler.

| Before (menu open) — search dropped below | After (menu open) — search stays top-right |
|---|---|
| <img src="https://raw.githubusercontent.com/KangaZero/neovim.github.io/responsive-assets/assets/responsive/navbar-open-before-500.png" width="100%"> | <img src="https://raw.githubusercontent.com/KangaZero/neovim.github.io/responsive-assets/assets/responsive/navbar-open-after-500.png" width="100%"> |

### 2. Masthead call-to-action buttons (≤ 525px)

On narrow viewports the **Install Now** / **Get Plugins** buttons now stack into their own full-width rows — much larger, easier tap targets for mobile — instead of sitting cramped side by side.

| Before | After |
|---|---|
| <img src="https://raw.githubusercontent.com/KangaZero/neovim.github.io/responsive-assets/assets/responsive/before-500.png" width="100%"> | <img src="https://raw.githubusercontent.com/KangaZero/neovim.github.io/responsive-assets/assets/responsive/after-500.png" width="100%"> |

### Notes
- Pure CSS plus one class hook (`<p class="lead-buttons-container">`); no structural HTML changes.
- Breakpoints: `525px` (matches existing usage in `main.css`) and `991.98px` (Bootstrap `lg` / `navbar-expand-lg`).
- Values use `em`, consistent with the surrounding file.