### PR TITLE
layout: stack footer columns on small screens

### DIFF
--- a/static/css/main.css
+++ b/static/css/main.css
@@ -493,6 +493,13 @@ footer {
   }
 }
 
+@media (max-width: 525px) {
+  footer .flex {
+    flex-direction: column;
+    text-align: center;
+  }
+}
+
 /*
  * Misc
  *


### PR DESCRIPTION
## What
On viewports narrower than 525px, stack the footer's two blocks (menu links and the source link) vertically and center their text, instead of leaving them in a cramped horizontal flex row.

| Before (~400px) | After (~400px) |
|---|---|
| <img src="https://raw.githubusercontent.com/KangaZero/neovim.github.io/responsive-assets/assets/responsive/footer-before-400.png" width="100%"> | <img src="https://raw.githubusercontent.com/KangaZero/neovim.github.io/responsive-assets/assets/responsive/footer-after-400.png" width="100%"> |

> ℹ️ Screenshots were captured with headless Chromium in its default theme, so the Neovim brand colors/fonts are not reflected — only the **layout** (stacking + centering) is relevant here. Actual colors match the live website.

## Why
The footer uses the shared `.flex` utility (`display: flex; justify-content: space-between`). On small screens the two blocks are squeezed side by side (links wrap on the left, the source link is crammed into a narrow right column). Stacking and centering them mirrors the mobile treatment already applied elsewhere (e.g. `.lead-buttons-container`), reusing the existing 525px breakpoint rather than introducing a new one.

## Notes
- Scoped to `footer .flex` — the `.flex` utility is also used by `404.html`, so it must not be changed globally.
- Pure CSS, one file, no markup changes. Verified locally with `hugo serve` (extended); site builds clean.
