### PR TITLE
layout: fix footer font-size on large screens

### DIFF
--- a/static/css/main.css
+++ b/static/css/main.css
@@ -1,6 +1,4 @@
 :root {
-  --main-breakpoint: 60em;
-
   --sans-serif-fonts: var(--bs-font-sans-serif);
 
   /* Colors */
@@ -487,7 +485,7 @@ footer {
   padding: 1em 0;
 }
 
-@media (min-width: var(--main-breakpoint)) {
+@media (min-width: 60em) {
   footer {
     font-size: 0.9em;
   }


### PR DESCRIPTION
## What
Just a very tiny nit and fix.
The footer's wide-screen `font-size: 0.9em` rule never applies, because its media query uses a custom property in the condition:

```css
@media (min-width: var(--main-breakpoint)) { /* var() is invalid here; --main-breakpoint: 60em */
  footer { font-size: 0.9em; }
}
```

## Why
`var()` is not valid inside a media query condition, so the browser discards the entire block and the footer keeps its inherited size on large screens.

> Variables do not work inside media queries and container queries. You can use the `var()` function in any part of a value in any property on an element. You cannot use `var()` for property names, selectors, or anything aside from property values, which means you can't use it in a media query or container query.

Source: [MDN: Using CSS custom properties](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_cascading_variables/Using_CSS_custom_properties)

Invalid media conditions fail silently. Since `--main-breakpoint` is referenced only here and nowhere else in the codebase, I suggest removing the `--main-breakpoint` variable and just putting in the hardcoded value in the media query. 

## How
Inline the `60em` literal into the condition and remove the now-unused `--main-breakpoint` variable. This also matches the file's existing convention, where every other `min-width` breakpoint (`30em`, `50em`) is a literal `em` value.

```css
@media (min-width: 60em) {
  footer { font-size: 0.9em; }
}
```

## Before / after (footer at ≥60em)
| Before (rule dropped, inherited size) | After (`0.9em` applies) |
| --- | --- |
| <img src="https://raw.githubusercontent.com/KangaZero/neovim.github.io/pr-footer-breakpoint-assets/assets/footer-breakpoint/footer-before.png" width="100%"> | <img src="https://raw.githubusercontent.com/KangaZero/neovim.github.io/pr-footer-breakpoint-assets/assets/footer-breakpoint/footer-after.png" width="100%"> |

_Note: captured via headless Chromium to isolate the footer; colors render normally in a real browser. The difference shown is the footer font-size._

## Alternative considered: `@custom-media` (limited browser availability for now)
`@custom-media` is the standards-track way to reference a named breakpoint inside a media query condition:

```css
@custom-media --main-breakpoint (min-width: 60em);
@media (--main-breakpoint) { footer { font-size: 0.9em; } }
```

This can be viable option in the future when availability is wide. 

Source: [MDN: @custom-media](https://developer.mozilla.org/en-US/docs/Web/CSS/Reference/At-rules/@custom-media)
